### PR TITLE
improve tdvp vmf

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Renormalizer is a python package based on tensor network states for electron-phonon quantum dynamics.
 
-[![Build Status](https://travis-ci.org/jjren/Renormalizer.svg?branch=master)](https://travis-ci.org/jjren/Renormalizer)
+[![Build Status](https://travis-ci.org/shuaigroup/Renormalizer.svg?branch=master)](https://travis-ci.org/shuaigroup/Renormalizer)
 ## Installation
 Installation guide can be found in the [project wiki](https://github.com/shuaigroup/Renormalizer/wiki/Installation-guide).
 

--- a/renormalizer/lib/integrate/_ivp/ivp.py
+++ b/renormalizer/lib/integrate/_ivp/ivp.py
@@ -525,7 +525,7 @@ def solve_ivp(
 
         if t_eval is None:
             ts.append(t)
-            ys.append(y)
+            ys[-1] = y
         else:
             # The value in t_eval equal to t will be included.
             if solver.direction > 0:

--- a/renormalizer/lib/krylov/krylov.py
+++ b/renormalizer/lib/krylov/krylov.py
@@ -47,7 +47,7 @@ def expm_krylov(Afunc, dt, vstart):
     res = None
 
     for j in range(len(vstart) - 1):
-        if MAX_ITER - 1 == j:
+        if MAX_ITER - 2 == j:
             raise RuntimeError("krylov not converged")
         w = Afunc(V[j])
         alpha[j] = xp.vdot(w, V[j]).real

--- a/renormalizer/mps/matrix.py
+++ b/renormalizer/mps/matrix.py
@@ -110,21 +110,21 @@ class Matrix:
     def l_combine(self):
         return self.reshape(self.l_combine_shape)
 
-    def check_lortho(self):
+    def check_lortho(self, atol=1e-8):
         """
         check L-orthogonal
         """
         tensm = self.array.reshape([np.prod(self.shape[:-1]), self.shape[-1]])
         s = xp.dot(tensm.T.conj(), tensm)
-        return allclose(s, xp.eye(s.shape[0]), atol=1e-3)
+        return allclose(s, xp.eye(s.shape[0]), atol=atol)
 
-    def check_rortho(self):
+    def check_rortho(self, atol=1e-8):
         """
         check R-orthogonal
         """
         tensm = self.array.reshape([self.shape[0], np.prod(self.shape[1:])])
         s = xp.dot(tensm, tensm.T.conj())
-        return allclose(s, xp.eye(s.shape[0]), atol=1e-3)
+        return allclose(s, xp.eye(s.shape[0]), atol=atol)
 
     def to_complex(self, inplace=False):
         # `xp.array` always creates new array, so to_complex means copy, which is

--- a/renormalizer/mps/mp.py
+++ b/renormalizer/mps/mp.py
@@ -182,21 +182,21 @@ class MatrixProduct:
             self.qn[idx] = [self.qntot - i for i in self.qn[idx]]
         self.qnidx = dstidx
 
-    def check_left_canonical(self):
+    def check_left_canonical(self, atol=1e-3):
         """
         check L-canonical
         """
         for mt in self[:-1]:
-            if not mt.check_lortho():
+            if not mt.check_lortho(atol):
                 return False
         return True
 
-    def check_right_canonical(self):
+    def check_right_canonical(self, atol=1e-3):
         """
         check R-canonical
         """
         for mt in self[1:]:
-            if not mt.check_rortho():
+            if not mt.check_rortho(atol):
                 return False
         return True
 
@@ -213,6 +213,13 @@ class MatrixProduct:
         check the qn center in the R-canonical structure
         """
         return self.qnidx == 0
+
+    def ensure_left_canon(self, atol=1e-3):
+        if not self.check_left_canonical(atol):
+            self.move_qnidx(0)
+            self.left = True
+            self.canonicalise()
+            assert self.check_left_canonical(atol)
 
     def iter_idx_list(self, full: bool, stop_idx: int=None):
         # if not `full`, the last site is omitted.
@@ -287,7 +294,6 @@ class MatrixProduct:
             self.qnidx = 0
             self.left = True
             # assert self.check_right_canonical()
-
 
     def _get_big_qn(self, idx):
         mt: Matrix = self[idx]

--- a/renormalizer/mps/tests/test_evolve.py
+++ b/renormalizer/mps/tests/test_evolve.py
@@ -15,14 +15,14 @@ from renormalizer.mps.tests import cur_dir
 @pytest.mark.parametrize(
     "method, evolve_dt, nsteps, use_rk, cmf_or_midpoint, rtol, interval",
     (
-    #    [EvolveMethod.tdvp_vmf, 15., 100, False, None, 1e-2, 1],
+        [EvolveMethod.tdvp_vmf, 15., 100, False, None, 1e-2, 1],
         [EvolveMethod.tdvp_mu_switch_gauge, 8, 50, None, False, 1e-2, 4],
         [EvolveMethod.tdvp_mu_switch_gauge, 4, 100, None, True, 1e-2, 2],
         [EvolveMethod.tdvp_mu_fixed_gauge, 6, 70, None, False, 1e-2, 3],
         [EvolveMethod.tdvp_mu_fixed_gauge, 12, 35, None, True, 1e-2, 6],
         [EvolveMethod.tdvp_ps, 15.0, 200, True, None, 1e-2, 1],
         [EvolveMethod.tdvp_ps, 15.0, 200, False, None, 1e-2, 1],
-    #    [EvolveMethod.tdvp_mu_vmf, 15.0, 100, False, None, 1e-2, 1],
+        [EvolveMethod.tdvp_mu_vmf, 15.0, 100, False, None, 1e-2, 1],
     ),
 )
 def test_ZeroTcorr_TDVP(method, evolve_dt, nsteps, use_rk, cmf_or_midpoint, rtol, interval):
@@ -35,6 +35,8 @@ def test_ZeroTcorr_TDVP(method, evolve_dt, nsteps, use_rk, cmf_or_midpoint, rtol
     evolve_config.tdvp_ps_rk4 = use_rk
     evolve_config.tdvp_mctdh_cmf = cmf_or_midpoint
     evolve_config.tdvp_mu_midpoint = cmf_or_midpoint
+    if method is EvolveMethod.tdvp_vmf:
+        evolve_config.reg_epsilon = 1e-5
 
     zero_t_corr = SpectraTwoWayPropZeroT(
         mol_list,
@@ -61,12 +63,12 @@ def test_ZeroTcorr_TDVP(method, evolve_dt, nsteps, use_rk, cmf_or_midpoint, rtol
 @pytest.mark.parametrize(
     "method, nsteps, evolve_dt, use_rk, rtol, interval",
     (
-        #[EvolveMethod.tdvp_vmf, 30, 6.,False, 1e-2, 3],
+        [EvolveMethod.tdvp_vmf, 30, 6.,False, 1e-2, 3],
         [EvolveMethod.tdvp_mu_switch_gauge, 10, 32, None, 1e-2, 16],
         [EvolveMethod.tdvp_mu_fixed_gauge, 5, 64, None, 1e-2, 32],
         [EvolveMethod.tdvp_ps, 30, 30, True, 1e-2, 1],
         [EvolveMethod.tdvp_ps, 30, 30, False, 1e-2, 1],
-        #[EvolveMethod.tdvp_mu_vmf, 30, 6, False, 1e-2, 3],
+        [EvolveMethod.tdvp_mu_vmf, 30, 6, False, 1e-2, 3],
     ),
 )
 def test_finite_t_spectra_emi_TDVP(method, nsteps, evolve_dt, use_rk, rtol, interval):
@@ -75,6 +77,8 @@ def test_finite_t_spectra_emi_TDVP(method, nsteps, evolve_dt, use_rk, rtol, inte
     offset = Quantity(2.28614053, "ev")
     evolve_config = EvolveConfig(method)
     evolve_config.tdvp_ps_rk4 = use_rk
+    if method is EvolveMethod.tdvp_vmf:
+        evolve_config.reg_epsilon = 1e-5
     
     finite_t_corr = SpectraFiniteT(
         mol_list, "emi", temperature, 50, offset, evolve_config=evolve_config


### PR DESCRIPTION
- Calculate S according to previous calculated S to improve efficiency.
- Hack into scipy ivp so that during one call of `solve_ivp` only one y is stored.
- Fix tests by larger regularization epsilon