### PR TITLE
implement eom when considering overlap between SPF

### DIFF
--- a/renormalizer/mps/backend.py
+++ b/renormalizer/mps/backend.py
@@ -58,8 +58,8 @@ class Backend:
         self.first_mp = False
         self._real_dtype = None
         self._complex_dtype = None
-        self.use_32bits()
-        #self.use_64bits()
+        #self.use_32bits()
+        self.use_64bits()
 
     def free_all_blocks(self):
         if xp == np:

--- a/renormalizer/mps/tests/test_evolve.py
+++ b/renormalizer/mps/tests/test_evolve.py
@@ -21,7 +21,7 @@ from renormalizer.mps.tests import cur_dir
         [EvolveMethod.tdvp_mu_switch_gauge, 8, 50, None, False, False, 1e-2, 4],
         [EvolveMethod.tdvp_mu_switch_gauge, 4, 100, None, False, True, 1e-2, 2],
         [EvolveMethod.tdvp_mu_fixed_gauge, 6, 70, None, False, False, 1e-2, 3],
-        [EvolveMethod.tdvp_mu_fixed_gauge, 12, 35, None, False, True, 1e-2, 6],
+        [EvolveMethod.tdvp_mu_fixed_gauge, 6, 35, None, False, True, 1e-2, 3],
         [EvolveMethod.tdvp_ps, 15.0, 200, True, False,  None, 1e-2, 1],
         [EvolveMethod.tdvp_ps, 15.0, 200, False, False, None, 1e-2, 1],
     ),
@@ -67,7 +67,7 @@ def test_ZeroTcorr_TDVP(method, evolve_dt, nsteps, use_rk, force_Ovlp, cmf_or_mi
     (
         [EvolveMethod.tdvp_vmf, 30, 6., None, False, 1e-2, 3],
         [EvolveMethod.tdvp_mu_vmf, 30, 6, None, False, 1e-2, 3],
-        #[EvolveMethod.tdvp_mu_vmf, 30, 6, None, True, 1e-2, 3],
+        [EvolveMethod.tdvp_mu_vmf, 30, 6, None, True, 1e-2, 3],
         [EvolveMethod.tdvp_mu_switch_gauge, 10, 32, None, False, 1e-2, 16],
         [EvolveMethod.tdvp_mu_fixed_gauge, 5, 64, None, False, 1e-2, 32],
         [EvolveMethod.tdvp_ps, 30, 30, True, False, 1e-2, 1],

--- a/renormalizer/mps/tests/test_evolve.py
+++ b/renormalizer/mps/tests/test_evolve.py
@@ -67,7 +67,7 @@ def test_ZeroTcorr_TDVP(method, evolve_dt, nsteps, use_rk, force_Ovlp, cmf_or_mi
     (
         [EvolveMethod.tdvp_vmf, 30, 6., None, False, 1e-2, 3],
         [EvolveMethod.tdvp_mu_vmf, 30, 6, None, False, 1e-2, 3],
-        [EvolveMethod.tdvp_mu_vmf, 30, 6, None, True, 1e-2, 3],
+        #[EvolveMethod.tdvp_mu_vmf, 30, 6, None, True, 1e-2, 3],
         [EvolveMethod.tdvp_mu_switch_gauge, 10, 32, None, False, 1e-2, 16],
         [EvolveMethod.tdvp_mu_fixed_gauge, 5, 64, None, False, 1e-2, 32],
         [EvolveMethod.tdvp_ps, 30, 30, True, False, 1e-2, 1],

--- a/renormalizer/mps/tests/test_evolve.py
+++ b/renormalizer/mps/tests/test_evolve.py
@@ -13,19 +13,20 @@ from renormalizer.mps.tests import cur_dir
 
 
 @pytest.mark.parametrize(
-    "method, evolve_dt, nsteps, use_rk, cmf_or_midpoint, rtol, interval",
+    "method, evolve_dt, nsteps, use_rk, force_Ovlp, cmf_or_midpoint, rtol, interval",
     (
-        [EvolveMethod.tdvp_vmf, 15., 100, False, None, 1e-2, 1],
-        [EvolveMethod.tdvp_mu_switch_gauge, 8, 50, None, False, 1e-2, 4],
-        [EvolveMethod.tdvp_mu_switch_gauge, 4, 100, None, True, 1e-2, 2],
-        [EvolveMethod.tdvp_mu_fixed_gauge, 6, 70, None, False, 1e-2, 3],
-        [EvolveMethod.tdvp_mu_fixed_gauge, 12, 35, None, True, 1e-2, 6],
-        [EvolveMethod.tdvp_ps, 15.0, 200, True, None, 1e-2, 1],
-        [EvolveMethod.tdvp_ps, 15.0, 200, False, None, 1e-2, 1],
-        [EvolveMethod.tdvp_mu_vmf, 15.0, 100, False, None, 1e-2, 1],
+        [EvolveMethod.tdvp_vmf, 15., 100, None, False, None, 1e-2, 1],
+        [EvolveMethod.tdvp_vmf, 15., 100, None, True, None, 1e-2, 1],
+        [EvolveMethod.tdvp_mu_vmf, 15.0, 100, None, False, None, 1e-2, 1],
+        [EvolveMethod.tdvp_mu_switch_gauge, 8, 50, None, False, False, 1e-2, 4],
+        [EvolveMethod.tdvp_mu_switch_gauge, 4, 100, None, False, True, 1e-2, 2],
+        [EvolveMethod.tdvp_mu_fixed_gauge, 6, 70, None, False, False, 1e-2, 3],
+        [EvolveMethod.tdvp_mu_fixed_gauge, 12, 35, None, False, True, 1e-2, 6],
+        [EvolveMethod.tdvp_ps, 15.0, 200, True, False,  None, 1e-2, 1],
+        [EvolveMethod.tdvp_ps, 15.0, 200, False, False, None, 1e-2, 1],
     ),
 )
-def test_ZeroTcorr_TDVP(method, evolve_dt, nsteps, use_rk, cmf_or_midpoint, rtol, interval):
+def test_ZeroTcorr_TDVP(method, evolve_dt, nsteps, use_rk, force_Ovlp, cmf_or_midpoint, rtol, interval):
     procedure = [[20, 0], [20, 0], [20, 0]]
     optimize_config = OptimizeConfig(procedure=procedure)
 
@@ -33,6 +34,7 @@ def test_ZeroTcorr_TDVP(method, evolve_dt, nsteps, use_rk, cmf_or_midpoint, rtol
 
     evolve_config = EvolveConfig(method, evolve_dt=evolve_dt, adaptive=False)
     evolve_config.tdvp_ps_rk4 = use_rk
+    evolve_config.force_Ovlp = force_Ovlp
     evolve_config.tdvp_mctdh_cmf = cmf_or_midpoint
     evolve_config.tdvp_mu_midpoint = cmf_or_midpoint
     if method is EvolveMethod.tdvp_vmf:
@@ -61,22 +63,25 @@ def test_ZeroTcorr_TDVP(method, evolve_dt, nsteps, use_rk, cmf_or_midpoint, rtol
 
 
 @pytest.mark.parametrize(
-    "method, nsteps, evolve_dt, use_rk, rtol, interval",
+    "method, nsteps, evolve_dt, use_rk, force_Ovlp, rtol, interval",
     (
-        [EvolveMethod.tdvp_vmf, 30, 6.,False, 1e-2, 3],
-        [EvolveMethod.tdvp_mu_switch_gauge, 10, 32, None, 1e-2, 16],
-        [EvolveMethod.tdvp_mu_fixed_gauge, 5, 64, None, 1e-2, 32],
-        [EvolveMethod.tdvp_ps, 30, 30, True, 1e-2, 1],
-        [EvolveMethod.tdvp_ps, 30, 30, False, 1e-2, 1],
-        [EvolveMethod.tdvp_mu_vmf, 30, 6, False, 1e-2, 3],
+        [EvolveMethod.tdvp_vmf, 30, 6., None, False, 1e-2, 3],
+        [EvolveMethod.tdvp_mu_vmf, 30, 6, None, False, 1e-2, 3],
+        [EvolveMethod.tdvp_mu_vmf, 30, 6, None, True, 1e-2, 3],
+        [EvolveMethod.tdvp_mu_switch_gauge, 10, 32, None, False, 1e-2, 16],
+        [EvolveMethod.tdvp_mu_fixed_gauge, 5, 64, None, False, 1e-2, 32],
+        [EvolveMethod.tdvp_ps, 30, 30, True, False, 1e-2, 1],
+        [EvolveMethod.tdvp_ps, 30, 30, False, False, 1e-2, 1],
     ),
 )
-def test_finite_t_spectra_emi_TDVP(method, nsteps, evolve_dt, use_rk, rtol, interval):
+def test_finite_t_spectra_emi_TDVP(method, nsteps, evolve_dt, use_rk,
+        force_Ovlp, rtol, interval):
     mol_list = parameter.mol_list
     temperature = Quantity(298, "K")
     offset = Quantity(2.28614053, "ev")
     evolve_config = EvolveConfig(method)
     evolve_config.tdvp_ps_rk4 = use_rk
+    evolve_config.force_Ovlp = force_Ovlp
     if method is EvolveMethod.tdvp_vmf:
         evolve_config.reg_epsilon = 1e-5
     

--- a/renormalizer/utils/configs.py
+++ b/renormalizer/utils/configs.py
@@ -210,7 +210,8 @@ class EvolveConfig:
         adaptive_rtol=5e-4,
         reg_epsilon=1e-10,
         ivp_rtol=1e-5,
-        ivp_atol=1e-8
+        ivp_atol=1e-8,
+        force_Ovlp=False
     ):
 
         self.method = method
@@ -233,6 +234,7 @@ class EvolveConfig:
         # scipy.ivp rtol and atol
         self.ivp_rtol: float = ivp_rtol
         self.ivp_atol: float = ivp_atol
+        self.force_Ovlp: bool = force_Ovlp
 
         # should adjust bond order before any tdvp evolution
         self._adjust_bond_dim_counter: bool = False
@@ -279,7 +281,8 @@ class EvolveConfig:
         return new
 
     def __str__(self):
-        attrs = ["method", "adaptive", "evolve_dt", "adaptive_rtol", "d_energy", "tdvp_ps_rk4"]
+        attrs = ["method", "adaptive", "evolve_dt", "adaptive_rtol", "d_energy",
+                "tdvp_ps_rk4", "reg_epsilon", "ivp_rtol", "ivp_atol", "force_Ovlp"]
         lines = []
         for attr in attrs:
             attr_value = getattr(self, attr)


### PR DESCRIPTION
In the VMF/CMF evolution scheme, the gauge condition is fixed to be left-canonical. However, in the actual numerical calculation, the condition is not fulfilled because of the finite time step. If the time step size is not appropriate, the overlap between different SPF function should be considered <\Psi_i|\Psi_j> = S_ij \neq \delta_ij.

A flag `force_Ovlp=False`  in `EvolveConfig` controls this feature. 
True/False: w/o considering the Overlap Matrix. The default is `False` now.


