### PR TITLE
Refactor test_evolve.py

### DIFF
--- a/renormalizer/mps/mp.py
+++ b/renormalizer/mps/mp.py
@@ -114,7 +114,11 @@ class MatrixProduct:
         )
         # return a list so that the logging result is more pretty
         return bond_dims
-    
+
+    @property
+    def bond_dims_max(self) -> int:
+        return np.max(self.bond_dims)
+
     @property
     def ephtable(self):
         if self._ephtable is not None:
@@ -386,6 +390,8 @@ class MatrixProduct:
         returns:
              truncated MPS
         """
+        if self.compress_config.bonddim_should_set:
+            self.compress_config.set_bonddim(len(self)+1)
         # used for logging at exit
         sz_before = self.total_bytes
         if not self.is_mpo:

--- a/renormalizer/mps/mpo.py
+++ b/renormalizer/mps/mpo.py
@@ -653,6 +653,8 @@ class Mpo(MatrixProduct):
         if rep is None:
             assert mol_list.scheme == 4
 
+        if not isinstance(offset, Quantity):
+            raise ValueError("offset must be Quantity object")
         super(Mpo, self).__init__()
         if mol_list is None:
             return
@@ -1143,6 +1145,9 @@ class Mpo(MatrixProduct):
     def is_hermitian(self):
         full = self.full_operator()
         return xp.allclose(full.array.conj().T, full, atol=1e-7)
+
+    def __matmul__(self, other):
+        return self.apply(other)
 
 class VirtualOnSite(Mpo):
     """

--- a/renormalizer/mps/tests/test_evolve.py
+++ b/renormalizer/mps/tests/test_evolve.py
@@ -3,107 +3,104 @@
 
 import os
 
+import qutip
 import pytest
 import numpy as np
 
-from renormalizer.spectra import SpectraTwoWayPropZeroT, SpectraFiniteT
-from renormalizer.utils import OptimizeConfig, EvolveMethod, EvolveConfig, Quantity
-from renormalizer.tests import parameter
-from renormalizer.mps.tests import cur_dir
+from renormalizer.mps import Mps, Mpo, MpDm
+from renormalizer.utils import EvolveMethod, EvolveConfig, CompressConfig, CompressCriteria, Quantity
+from renormalizer.tests.parameter_exact import qutip_clist, qutip_h, mol_list
 
 
-@pytest.mark.parametrize(
-    "method, evolve_dt, nsteps, use_rk, force_Ovlp, cmf_or_midpoint, rtol, interval",
-    (
-        [EvolveMethod.tdvp_vmf, 15., 100, None, False, None, 1e-2, 1],
-        [EvolveMethod.tdvp_vmf, 15., 100, None, True, None, 1e-2, 1],
-        [EvolveMethod.tdvp_mu_vmf, 15.0, 100, None, False, None, 1e-2, 1],
-        [EvolveMethod.tdvp_mu_switch_gauge, 8, 50, None, False, False, 1e-2, 4],
-        [EvolveMethod.tdvp_mu_switch_gauge, 4, 100, None, False, True, 1e-2, 2],
-        [EvolveMethod.tdvp_mu_fixed_gauge, 6, 70, None, False, False, 1e-2, 3],
-        [EvolveMethod.tdvp_mu_fixed_gauge, 6, 35, None, False, True, 1e-2, 3],
-        [EvolveMethod.tdvp_ps, 15.0, 200, True, False,  None, 1e-2, 1],
-        [EvolveMethod.tdvp_ps, 15.0, 200, False, False, None, 1e-2, 1],
-    ),
-)
-def test_ZeroTcorr_TDVP(method, evolve_dt, nsteps, use_rk, force_Ovlp, cmf_or_midpoint, rtol, interval):
-    procedure = [[20, 0], [20, 0], [20, 0]]
-    optimize_config = OptimizeConfig(procedure=procedure)
+# the init state
+tentative_mpo = Mpo(mol_list)
+init_mps = (Mpo.onsite(mol_list, r"a^\dagger", mol_idx_set={0}) @ Mps.gs(mol_list, False)).expand_bond_dimension(hint_mpo=tentative_mpo)
+init_mpdm = MpDm.from_mps(init_mps).expand_bond_dimension(hint_mpo=tentative_mpo)
+e = init_mps.expectation(tentative_mpo)
+mpo = Mpo(mol_list, offset=Quantity(e))
 
-    mol_list = parameter.mol_list
-
-    evolve_config = EvolveConfig(method, evolve_dt=evolve_dt, adaptive=False)
-    evolve_config.tdvp_ps_rk4 = use_rk
-    evolve_config.force_Ovlp = force_Ovlp
-    evolve_config.tdvp_mctdh_cmf = cmf_or_midpoint
-    evolve_config.tdvp_mu_midpoint = cmf_or_midpoint
-    if method is EvolveMethod.tdvp_vmf:
-        evolve_config.reg_epsilon = 1e-5
-
-    zero_t_corr = SpectraTwoWayPropZeroT(
-        mol_list,
-        "abs",
-        optimize_config,
-        evolve_config=evolve_config,
-        offset=Quantity(2.28614053, "ev"),
-    )
-    zero_t_corr.info_interval = 30
-    zero_t_corr.evolve(evolve_dt, nsteps)
-    file_name_mapping = {
-        EvolveMethod.tdvp_mu_switch_gauge: "zero_t_tdvp_mu.npy",
-        EvolveMethod.tdvp_mu_fixed_gauge: "zero_t_tdvp_mu.npy",
-        EvolveMethod.tdvp_mu_vmf: "zero_t_tdvp_ps.npy",
-        EvolveMethod.tdvp_vmf: "zero_t_tdvp_ps.npy",
-        EvolveMethod.tdvp_ps: "zero_t_tdvp_ps.npy"
-    }
-    fname = file_name_mapping[method]
-    with open(os.path.join(cur_dir, fname),"rb") as f:
-        std = np.load(f)
-    assert np.allclose(zero_t_corr.autocorr[:nsteps], std[:interval*nsteps:interval], rtol=rtol)
+# calculate exact result in ZT. FT result is exactly the same
+TIME_LIMIT = 10
+QUTIP_STEP = 0.01
+N_POINTS = TIME_LIMIT / QUTIP_STEP + 1
+qutip_time_series = np.linspace(0, TIME_LIMIT, N_POINTS)
+init = qutip.Qobj(init_mps.full_wfn(), [qutip_h.dims[0], [1] * len(qutip_h.dims[0])])
+# the result is not exact and the error scale is approximately 1e-5
+res = qutip.sesolve(qutip_h-e, init, qutip_time_series, e_ops=[c.dag() * c for c in qutip_clist])
+qutip_expectations = np.array(res.expect).T
 
 
-@pytest.mark.parametrize(
-    "method, nsteps, evolve_dt, use_rk, force_Ovlp, rtol, interval",
-    (
-        [EvolveMethod.tdvp_vmf, 30, 6., None, False, 1e-2, 3],
-        [EvolveMethod.tdvp_mu_vmf, 30, 6, None, False, 1e-2, 3],
-        [EvolveMethod.tdvp_mu_vmf, 30, 6, None, True, 1e-2, 3],
-        [EvolveMethod.tdvp_mu_switch_gauge, 10, 32, None, False, 1e-2, 16],
-        [EvolveMethod.tdvp_mu_fixed_gauge, 5, 64, None, False, 1e-2, 32],
-        [EvolveMethod.tdvp_ps, 30, 30, True, False, 1e-2, 1],
-        [EvolveMethod.tdvp_ps, 30, 30, False, False, 1e-2, 1],
-    ),
-)
-def test_finite_t_spectra_emi_TDVP(method, nsteps, evolve_dt, use_rk,
-        force_Ovlp, rtol, interval):
-    mol_list = parameter.mol_list
-    temperature = Quantity(298, "K")
-    offset = Quantity(2.28614053, "ev")
-    evolve_config = EvolveConfig(method)
-    evolve_config.tdvp_ps_rk4 = use_rk
-    evolve_config.force_Ovlp = force_Ovlp
-    if method is EvolveMethod.tdvp_vmf:
-        evolve_config.reg_epsilon = 1e-5
-    
-    finite_t_corr = SpectraFiniteT(
-        mol_list, "emi", temperature, 50, offset, evolve_config=evolve_config
-    )
-    finite_t_corr.evolve(evolve_dt, nsteps)
-    
-    file_name_mapping = {
-        EvolveMethod.tdvp_mu_switch_gauge: "finite_t_tdvp_mu.npy",
-        EvolveMethod.tdvp_mu_fixed_gauge: "finite_t_tdvp_mu.npy",
-        EvolveMethod.tdvp_ps: "finite_t_tdvp_ps.npy",
-        EvolveMethod.tdvp_mu_vmf: "finite_t_tdvp_mu.npy",
-        EvolveMethod.tdvp_vmf: "finite_t_tdvp_mu.npy"
-    }
-    fname = file_name_mapping[method]
-    with open(os.path.join(cur_dir, fname),"rb") as f:
-        std = np.load(f)
-    assert np.allclose(
-        finite_t_corr.autocorr[:nsteps], std[:interval*nsteps:interval], rtol=rtol
-    )
-    # from matplotlib import pyplot as plt
-    # plt.plot(finite_t_corr.autocorr)
-    # plt.plot(std)
-    # plt.show()
+def check_result(mps, mpo, time_step, final_time, atol=1e-4):
+    # the information to be compared with the standard
+    expectations = [mps.e_occupations]
+    # useful in debugging
+    time_series = [0]
+    for i in range(round(final_time / time_step)):
+        mps = mps.evolve(mpo, time_step)
+        expectations.append(mps.e_occupations)
+        time_series.append(time_series[-1] + time_step)
+    qutip_end = round(final_time / QUTIP_STEP) + 1
+    qutip_interval = round(time_step / QUTIP_STEP)
+    # used for debugging
+    mcd = np.abs(expectations - qutip_expectations[:qutip_end:qutip_interval]).mean()
+    assert mcd < atol
+
+# useful debugging code
+# from matplotlib import pyplot as plt
+# plt.plot(time_series, expectations)
+# plt.plot(qutip_time_series[:qutip_end], qutip_expectations[:qutip_end])
+# plt.show()
+
+
+@pytest.mark.parametrize("init_state", (init_mps, init_mpdm))
+def test_pc(init_state):
+    mps = init_state.copy()
+    mps.compress_config  = CompressConfig(CompressCriteria.fixed)
+    check_result(mps, mpo, 0.2, 5)
+
+
+@pytest.mark.parametrize("init_state, atol", ([init_mps, 1e-4], [init_mpdm, 1e-3]))
+@pytest.mark.parametrize("with_mu", (True, False))
+@pytest.mark.parametrize("force_ovlp", (True, False))
+def test_tdvp_vmf(init_state, with_mu, force_ovlp, atol):
+    mps = init_state.copy()
+    method = EvolveMethod.tdvp_mu_vmf if with_mu else EvolveMethod.tdvp_vmf
+    mps.evolve_config  = EvolveConfig(method, force_ovlp=force_ovlp)
+    check_result(mps, mpo, 0.5, 2, atol)
+
+
+@pytest.mark.parametrize("init_state", (init_mps, init_mpdm))
+def test_tdvp_cmf(init_state):
+    mps = init_state.copy()
+    mps.evolve_config  = EvolveConfig(EvolveMethod.tdvp_mu_cmf)
+    check_result(mps, mpo, 0.01, 0.5, 5e-4)
+
+
+@pytest.mark.parametrize("init_state", (
+        init_mps,
+        init_mpdm,))
+def test_tdvp_ps(init_state):
+    mps = init_state.copy()
+    mps.evolve_config  = EvolveConfig(EvolveMethod.tdvp_ps)
+    check_result(mps, mpo, 0.5, 5)
+
+
+# used for debugging
+def compare():
+    dt_list = [0.01, 0.02, 0.05, 0.1, 0.2, 0.4]
+    method_list = [EvolveMethod.prop_and_compress, EvolveMethod.tdvp_mu_vmf, EvolveMethod.tdvp_mu_cmf, EvolveMethod.tdvp_ps]
+    all_values = []
+    for method in method_list:
+        values = []
+        for dt in dt_list:
+            mps = init_mps.copy()
+            mps.compress_config = CompressConfig(CompressCriteria.fixed)
+            mps.evolve_config  = EvolveConfig(method)
+            mps.evolve_config._adjust_bond_dim_counter = True
+            mps.evolve_config.force_ovlp = True
+            values.append(check_result(mps, mpo, dt, 2))
+        print(values)
+        all_values.append(values)
+    print(mps.bond_dims)
+    print(all_values)
+

--- a/renormalizer/mps/tests/test_mp.py
+++ b/renormalizer/mps/tests/test_mp.py
@@ -29,8 +29,8 @@ def test_save_load():
 def check_distance(a: Mps ,b: Mps):
     d1 = (a - b).dmrg_norm
     d2 = a.distance(b)
-    a_array = a.full_wfn().asnumpy()
-    b_array = b.full_wfn().asnumpy()
+    a_array = a.full_wfn()
+    b_array = b.full_wfn()
     d3 = np.linalg.norm(a_array - b_array)
     assert d1 == pytest.approx(d2) == pytest.approx(d3)
 

--- a/renormalizer/mps/tests/test_mpo.py
+++ b/renormalizer/mps/tests/test_mpo.py
@@ -97,7 +97,7 @@ def test_displacement():
     gs = Mps.gs(mol_list, max_entangled=False)
     gs = Mpo.onsite(mol_list, r"a^\dagger", mol_idx_set={0}).apply(gs).compress()
     assert np.allclose(gs.e_occupations, get_e_occu(0))
-    gs = Mpo.displacement(mol_list, 0, 2).apply(gs)
+    gs = Mpo.displacement(mol_list, 0, 2) @ gs
     assert np.allclose(gs.e_occupations, get_e_occu(2))
-    gs = Mpo.displacement(mol_list, 2, 0).apply(gs)
+    gs = Mpo.displacement(mol_list, 2, 0) @ gs
     assert np.allclose(gs.e_occupations ,get_e_occu(0))

--- a/renormalizer/mps/tests/test_mpproperty.py
+++ b/renormalizer/mps/tests/test_mpproperty.py
@@ -26,7 +26,7 @@ def check_property(mp):
 
 def test_mps():
     gs_mps = Mps.gs(mol_list, max_entangled=False)
-    mps = creation_operator.apply(gs_mps)
+    mps = creation_operator @ gs_mps
     check_property(mps)
 
 
@@ -36,5 +36,5 @@ def test_mpo():
     tp = ThermalProp(gs_dm, Mpo(gs_dm.mol_list), exact=True, space="GS")
     tp.evolve(None, 500, beta / 1j)
     gs_dm = tp.latest_mps
-    mp = creation_operator.apply(gs_dm)
+    mp = creation_operator @ gs_dm
     check_property(mp)

--- a/renormalizer/mps/thermalprop.py
+++ b/renormalizer/mps/thermalprop.py
@@ -31,6 +31,8 @@ class ThermalProp(TdMpsJob):
     def init_mps(self):
         self.init_mpdm.evolve_config = self.evolve_config
         self.energies.append(self.init_mpdm.expectation(self.h_mpo))
+        if self.evolve_config.is_tdvp:
+            self.init_mpdm = self.init_mpdm.expand_bond_dimension(self.h_mpo)
         return self.init_mpdm
 
     def process_mps(self, mps):

--- a/renormalizer/sbm/sbm.py
+++ b/renormalizer/sbm/sbm.py
@@ -39,6 +39,7 @@ class SpinBosonModel(TdMpsJob):
         init_mps.evolve_config = self.evolve_config
         init_mps.use_dummy_qn = True
         self.h_mpo = Mpo(self.mol_list, offset=Quantity(init_mps.expectation(self.h_mpo)))
+        init_mps = init_mps.expand_bond_dimension(self.h_mpo)
         return init_mps
 
     def process_mps(self, mps):

--- a/renormalizer/tests/parameter_exact.py
+++ b/renormalizer/tests/parameter_exact.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+import numpy as np
+
+from renormalizer.mps import Mpo
+from renormalizer.model import Phonon, Mol, MolList
+from renormalizer.utils import Quantity
+from renormalizer.utils.qutip_utils import get_clist, get_blist, get_hamiltonian, get_gs
+
+
+OMEGA = 1
+DISPLACEMENT = 1
+N_LEVELS = 2
+N_SITES = 3
+J = 1
+
+ph = Phonon.simple_phonon(Quantity(OMEGA), Quantity(DISPLACEMENT), N_LEVELS)
+mol = Mol(Quantity(0), [ph])
+mol_list = MolList([mol] * N_SITES, Quantity(J), 3)
+
+qutip_clist = get_clist(N_SITES, N_LEVELS)
+qutip_blist = get_blist(N_SITES, N_LEVELS)
+
+G = np.sqrt(DISPLACEMENT**2 * OMEGA / 2)
+qutip_h = get_hamiltonian(N_SITES, J, OMEGA, G, qutip_clist, qutip_blist)
+
+qutip_gs = get_gs(N_SITES, N_LEVELS)

--- a/renormalizer/utils/qutip_utils.py
+++ b/renormalizer/utils/qutip_utils.py
@@ -49,6 +49,14 @@ def get_hamiltonian(nsites, J, omega, g, clist, blist):
     return H
 
 
+def get_gs(nsites, ph_levels):
+    basis = []
+    for i in range(nsites):
+        basis.append(qutip.states.basis(2))
+        basis.append(qutip.states.basis(ph_levels))
+    return qutip.tensor(basis)
+
+
 def get_qnidx(ph_levels, nsites):
     particles = np.array(list(product(*[[0, 1], [0] * ph_levels] * nsites))).sum(axis=1)
     return np.where(particles == 1)[0]


### PR DESCRIPTION
Refactor test_evolve.py to reduce time costs according to #25 .
A new set of parameters with total Hilbert space 64 is introduced in `test/parameter_exact.py` and reference dynamic is obtained by `qutip`. 

The commit also contains some other changes:
- TDVP_MU with swtich-gauge is removed to be consistent with the paper.
- A method `expand_bond_dimension` to add basis to MPSs is included in `MatrixProductStates`
- No need to call `set_bonddim` before compression. It's automatically done.

PS: I've forgotten to remove previous reference `npy` files. This will be done along with any future modification suggested by reviewers or before merging.