### PR TITLE
improve charge transport

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,8 @@ install:
 
 script:
     - pytest --durations=0
-    - cd example; bash run.sh
-
-before_deploy:
-    - pip install recommonmark==0.6.0
-    - pip install sphinx_rtd_theme==0.4.3
-    - cd doc; make html
+    - cd example; bash run.sh; cd ..
+    - cd doc; make html; cd ..
 
 deploy:
     provider: pages

--- a/renormalizer/__init__.py
+++ b/renormalizer/__init__.py
@@ -12,8 +12,8 @@ for env in ["MKL_NUM_THREADS", "NUMEXPR_NUM_THREADS", "OMP_NUM_THREADS"]:
     os.environ[env] = "1"
     del env
 
-# NEP-18. Not working. see gh-cupy/cupy#2130
-# os.environ["NUMPY_EXPERIMENTAL_ARRAY_FUNCTION"] = "1"
+# NEP-18 not working. For compatibility of newer NumPy version. See gh-cupy/cupy#2130
+os.environ["NUMPY_EXPERIMENTAL_ARRAY_FUNCTION"] = "0"
 
 del os, sys
 

--- a/renormalizer/lib/krylov/krylov.py
+++ b/renormalizer/lib/krylov/krylov.py
@@ -14,7 +14,13 @@ logger = logging.getLogger(__name__)
 
 def _expm_krylov(alpha, beta, V, v_norm, dt):
     # diagonalize Hessenberg matrix
-    w_hess, u_hess = eigh_tridiagonal(alpha, beta)
+    try:
+        w_hess, u_hess = eigh_tridiagonal(alpha, beta)
+    except np.linalg.LinAlgError:
+        logger.warning("tridigonal failed")
+        h = np.diag(alpha) + np.diag(beta, k=-1) + np.diag(beta, k=1)
+        w_hess, u_hess = np.linalg.eigh(h)
+
     xp_w_hess = xp.array(w_hess)
     xp_u_hess = xp.array(u_hess)
 
@@ -36,8 +42,8 @@ def expm_krylov(Afunc, dt, vstart):
     nrmv = xp.linalg.norm(vstart)
     assert nrmv > 0
     vstart = vstart / nrmv
-    # max iteration
-    MAX_ITER = 50
+    # max iteration. How to do this more cleverly?
+    MAX_ITER = 300
 
     alpha = np.zeros(MAX_ITER)
     beta  = np.zeros(MAX_ITER-1)

--- a/renormalizer/model/mlist.py
+++ b/renormalizer/model/mlist.py
@@ -51,10 +51,6 @@ class MolList:
         # reusable mpos for the system
         self.mpos = dict()
 
-        # originally designed for symmetry enforced evolution. Not implemented
-        # need symmetric MPO but we currently don't have one.
-        self.is_symmetric = self.check_symmetric()
-
     @property
     def mol_num(self):
         return len(self.mol_list)
@@ -107,17 +103,6 @@ class MolList:
         else:
             mpos = self.mpos[key]
         return mpos
-
-    def check_symmetric(self):
-        # first check for j matrix
-        rot = np.rot90(self.j_matrix)
-        if not np.allclose(rot, rot.T):
-            return False
-        # then check for mols
-        for i in range(len(self.mol_list) // 2):
-            if self.mol_list[i] != self.mol_list[-i]:
-                return False
-        return True
 
     def check_nearest_neighbour(self):
         d = np.diag(np.diag(self.j_matrix, k=1), k=1)

--- a/renormalizer/model/tests/test_mollist.py
+++ b/renormalizer/model/tests/test_mollist.py
@@ -1,12 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from renormalizer.tests.parameter import mol_list
-from renormalizer.tests.parameter_PBI import construct_mol
-
-
-def test_symmetry():
-    assert not mol_list.is_symmetric
-    assert construct_mol(10, 10, 0).is_symmetric
 
 
 def test_idx():

--- a/renormalizer/mps/mpdm.py
+++ b/renormalizer/mps/mpdm.py
@@ -159,7 +159,7 @@ class MpDm(MpDmBase):
         mpo.qn = [qn.copy() for qn in mps.qn]
         mpo.qntot = mps.qntot
         mpo.qnidx = mps.qnidx
-        mpo.left = mps.left
+        mpo.to_right = mps.to_right
         mpo.compress_config = mps.compress_config.copy()
         return mpo
 
@@ -199,7 +199,7 @@ class MpDm(MpDmBase):
             copy = self.copy().canonicalise()
             copy.canonicalise(self.mol_list.e_idx())
             e_mo = copy[self.mol_list.e_idx()]
-            return tensordot(e_mo, e_mo.conj(), axes=((0, 2 ,3), (0, 2, 3))).asnumpy()
+            return tensordot(e_mo, e_mo.conj(), axes=((0, 2 ,3), (0, 2, 3))).asnumpy()[1:, 1:]
         else:
             assert False
 

--- a/renormalizer/mps/mpo.py
+++ b/renormalizer/mps/mpo.py
@@ -577,7 +577,7 @@ class Mpo(MatrixProduct):
                 mpo.qn.append([qn])
         mpo.qntot = 0
         mpo.qnidx = len(mpo) - 1
-        mpo.left = False
+        mpo.to_right = False
         return mpo
 
     @classmethod

--- a/renormalizer/transport/tests/test_transport.py
+++ b/renormalizer/transport/tests/test_transport.py
@@ -103,33 +103,6 @@ def assert_iterable_equal(i1, i2):
     for ii1, ii2 in zip(i1, i2):
         assert_iterable_equal(ii1, ii2)
 
-@pytest.mark.parametrize(
-    "mol_num, j_constant_value, elocalex_value, ph_info, ph_phys_dim, evolve_dt, nsteps",
-    ([5, 0.8, 3.87e-3, [[1345.6738910804488, 16.274571056529368]], 4, 2, 50],),
-)
-def test_compress_add(
-    mol_num, j_constant_value, elocalex_value, ph_info, ph_phys_dim, evolve_dt, nsteps
-):
-    ph_list = [
-        Phonon.simple_phonon(
-            Quantity(omega, "cm^{-1}"), Quantity(displacement, "a.u."), ph_phys_dim
-        )
-        for omega, displacement in ph_info
-    ]
-    mol_list = MolList(
-        [Mol(Quantity(elocalex_value, "a.u."), ph_list)] * mol_num,
-        Quantity(j_constant_value, "eV"),
-        scheme=3
-    )
-    ct1 = ChargeTransport(mol_list, temperature=Quantity(298, "K"))
-    ct1.reduced_density_matrices = None
-    ct1.evolve(evolve_dt, nsteps)
-    ct2 = ChargeTransport(mol_list, temperature=Quantity(298, "K"))
-    ct2.reduced_density_matrices = None
-    ct2.latest_mps.compress_add = True
-    ct2.evolve(evolve_dt, nsteps)
-    assert ct1.is_similar(ct2, rtol=1e-2)
-
 
 @pytest.mark.parametrize(
     "mol_num, j_constant_value, elocalex_value, ph_info, ph_phys_dim, evolve_dt, nsteps, temperature",
@@ -137,6 +110,13 @@ def test_compress_add(
         [3, 0.8, 3.87e-3, [[1345.6738910804488, 16.274571056529368]], 4, 2, 15, 0],
         [3, 0.8, 3.87e-3, [[1345.6738910804488, 16.274571056529368]], 4, 2, 15, 100],
     ),
+)
+@pytest.mark.parametrize(
+    "scheme",
+    (
+            3,
+            4,
+     )
 )
 def test_reduced_density_matrix(
     mol_num,
@@ -147,6 +127,7 @@ def test_reduced_density_matrix(
     evolve_dt,
     nsteps,
     temperature,
+    scheme,
 ):
     ph_list = [
         Phonon.simple_phonon(
@@ -157,7 +138,7 @@ def test_reduced_density_matrix(
     mol_list = MolList(
         [Mol(Quantity(elocalex_value, "a.u."), ph_list)] * mol_num,
         Quantity(j_constant_value, "eV"),
-        scheme=3
+        scheme=scheme
     )
     ct = ChargeTransport(mol_list, temperature=Quantity(temperature, "K"), stop_at_edge=False, rdm=True)
     ct.evolve(evolve_dt, nsteps)

--- a/renormalizer/utils/tdmps.py
+++ b/renormalizer/utils/tdmps.py
@@ -109,21 +109,22 @@ class TdMpsJob(object):
                 self.evolve_config.evolve_dt = new_dt
             self.latest_mps = new_mps
             self.process_mps(new_mps)
-            new_wall_time = datetime.now()
-            time_cost = new_wall_time - wall_times[-1]
+            evolution_wall_time = datetime.now()
+            time_cost = evolution_wall_time - wall_times[-1]
             if self.info_interval is not None and i % self.info_interval == 0:
                 mps_abstract = str(new_mps)
             else:
                 mps_abstract = ""
-            logger.info(
-                "%s complete, time cost %s. %s" % (step_str, time_cost, mps_abstract)
-            )
-            wall_times.append(new_wall_time)
+            logger.info(f"Evolution of {step_str} complete, time cost {time_cost}. {mps_abstract}")
+            wall_times.append(evolution_wall_time)
             if self._defined_output_path:
                 try:
                     self.dump_dict()
                 except IOError:  # never quit calculation because of IOError
                     logger.exception("dumping dict failed with IOError")
+                dump_wall_time = datetime.now()
+                logger.info(f"Dumping time cost {dump_wall_time - evolution_wall_time}")
+
             if self.stop_evolve_criteria():
                 logger.info(
                     "Criteria to stop the evolution has met. Stop the evolution"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ h5py==2.9.0
 typing==3.6.6
 PyYAML==5.1
 Cython==0.29.6
+recommonmark==0.6.0
+sphinx_rtd_theme==0.4.3


### PR DESCRIPTION
Add documents to `ChargeTransport` and add a new attribute -- k-space occupations. Details can be found in the code and documentation.

Some other changes:
- Refactored some code, including renaming the ambiguous `left` to `to_right` in order to be more explicit.
- Fixed a bug of not calculating reduced density matrices correctly in scheme 4, which is introduced in #27 .