### PR TITLE
clever krylov expm method with adaptive buffer size

### DIFF
--- a/doc/source/ct.md
+++ b/doc/source/ct.md
@@ -1,1 +1,0 @@
-# Charge Transport

--- a/doc/source/ct.rst
+++ b/doc/source/ct.rst
@@ -1,0 +1,13 @@
+Charge Transport
+*************************************
+
+charge diffusion simulation
+===========================
+.. automodule:: renormalizer.transport.transport
+   :members:
+
+
+obtain mobility by Kubo formula
+===============================
+.. automodule:: renormalizer.transport.autocorr
+   :members:

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -20,7 +20,7 @@ Contents
    install.md
    spectrum.rst
    ct.rst
-   cv.md
+   cv.rst
    lib.md
    mps.md
    model.md

--- a/renormalizer/lib/tests/test_krylov.py
+++ b/renormalizer/lib/tests/test_krylov.py
@@ -13,7 +13,8 @@ from renormalizer.lib import expm_krylov
     800
 ))
 @pytest.mark.parametrize("imag", (True, False))
-def test_expm(N, imag):
+@pytest.mark.parametrize("block_size", (3, 30))
+def test_expm(N, imag, block_size):
     a1 = np.random.rand(N, N) / N
     if imag:
         a1 = a1 + np.random.rand(N, N) / N / 1j
@@ -22,5 +23,5 @@ def test_expm(N, imag):
     if imag:
         v = v + v / 1j
     res1 = expm(a1) @ v
-    res2, _ = expm_krylov(lambda x: a2.dot(x), 1, xp.array(v))
+    res2, _ = expm_krylov(lambda x: a2.dot(x), 1, xp.array(v), block_size)
     assert xp.allclose(res1, res2)

--- a/renormalizer/transport/transport.py
+++ b/renormalizer/transport/transport.py
@@ -189,7 +189,7 @@ class ChargeTransport(TdMpsJob):
         logger.info(f"mpo physical dims: {self.mpo.pbond_list}")
         init_mp.evolve_config = self.evolve_config
         init_mp.compress_config = self.compress_config
-        if self.evolve_config.is_tdvp and self.temperature == 0:
+        if self.evolve_config.is_tdvp:
             init_mp = init_mp.expand_bond_dimension(self.mpo)
         if self.dissipation != 0:
             self.mpo = SuperLiouville(self.mpo, self.dissipation)


### PR DESCRIPTION
Previously the `krylov_expm` method has a fixed `MAX_ITER=50` which is considered to be set to large enough value. However, in practice the actual size required varies from 10 to 300. Note that when `MAX_ITER=300` a huge amount of memory is required which may not be necessary for other systems. 

Therefore I added some simple algorithms to make the buffer of the size adaptive, which is expanding the size of the buffer with `block_size` every time larger buffer is required. The user may provide a more reasonable `block_size` than the default value based on the previous number of Krylov vectors.

The tail in #47 is also fixed.