### PR TITLE
modify finite td emission spectra

### DIFF
--- a/renormalizer/cv/finitet.py
+++ b/renormalizer/cv/finitet.py
@@ -131,8 +131,7 @@ class SpectraFtCV(SpectraCv):
                     logger.debug(f"no file found in {self._thermal_dump_path}")
                     tp.evolve(None, self.insteps, beta / 2j)
                     ket_mpo = tp.latest_mps
-        if tp._defined_output_path:
-            ket_mpo.dump(self._thermal_dump_path)
+                    ket_mpo.dump(self._thermal_dump_path)
         self.a_ket_mpo = dipole_mpo.apply(ket_mpo, canonicalise=True)
         self.cv_mpo = Mpo.finiteT_cv(self.mol_list, 1, self.m_max,
                                      self.spectratype, percent=1.0)

--- a/renormalizer/spectra/base.py
+++ b/renormalizer/spectra/base.py
@@ -16,6 +16,8 @@ class SpectraTdMpsJobBase(TdMpsJob):
         temperature,
         evolve_config=None,
         offset=Quantity(0),
+        dump_dir=None,
+        job_name=None
     ):
         self.mol_list = mol_list
         assert spectratype in ["emi", "abs"]
@@ -27,7 +29,7 @@ class SpectraTdMpsJobBase(TdMpsJob):
         self.temperature = temperature
         self.h_mpo = Mpo(mol_list, offset=offset)
         self._autocorr = []
-        super(SpectraTdMpsJobBase, self).__init__(evolve_config=evolve_config)
+        super(SpectraTdMpsJobBase, self).__init__(evolve_config=evolve_config, dump_dir=dump_dir, job_name=job_name)
 
     def process_mps(self, braket_pair):
         self._autocorr.append(braket_pair.ft)

--- a/renormalizer/spectra/finitet.py
+++ b/renormalizer/spectra/finitet.py
@@ -5,6 +5,12 @@ import numpy as np
 from renormalizer.mps import Mpo, MpDm, ThermalProp
 from renormalizer.spectra.base import SpectraTdMpsJobBase
 from renormalizer.mps.mps import BraKetPair
+from renormalizer.utils import CompressConfig, EvolveConfig
+from renormalizer.utils.utils import cast_float
+import os
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class BraKetPairEmiFiniteT(BraKetPair):
@@ -25,17 +31,31 @@ class SpectraFiniteT(SpectraTdMpsJobBase):
         insteps,
         offset,
         evolve_config=None,
+        icompress_config=None,
+        ievolve_config=None,
         gs_shift=0,
+        dump_dir: str=None,
+        job_name=None,
     ):
         self.temperature = temperature
         self.insteps = insteps
         self.gs_shift = gs_shift
+        self.icompress_config = icompress_config
+        self.ievolve_config = ievolve_config
+        if self.icompress_config is None:
+            self.icompress_config = CompressConfig()
+        if self.ievolve_config is None:
+            self.ievolve_config = EvolveConfig()
+        self.dump_dir = dump_dir
+        self.job_name = job_name
         super(SpectraFiniteT, self).__init__(
             mol_list,
             spectratype,
             temperature,
             evolve_config=evolve_config,
             offset=offset,
+            dump_dir=dump_dir,
+            job_name=job_name
         )
 
     def init_mps(self):
@@ -47,10 +67,31 @@ class SpectraFiniteT(SpectraTdMpsJobBase):
     def init_mps_emi(self):
         dipole_mpo = Mpo.onsite(self.mol_list, "a", dipole=True)
         i_mpo = MpDm.max_entangled_ex(self.mol_list)
+        i_mpo.compress_config = self.icompress_config
+        if self.job_name is None:
+            job_name = None
+        else:
+            job_name = self.job_name + "_thermal_prop"
         # only propagate half beta
-        tp = ThermalProp(i_mpo, self.h_mpo)
-        tp.evolve(None, self.insteps, self.temperature.to_beta() / 2j)
-        ket_mpo = tp.latest_mps
+        tp = ThermalProp(
+            i_mpo, self.h_mpo, evolve_config=self.ievolve_config,
+            dump_dir=self.dump_dir, job_name=job_name
+        )
+        if tp._defined_output_path:
+            try:
+                logger.info(
+                    f"load density matrix from {self._thermal_dump_path}"
+                )
+                ket_mpo = MpDm.load(self.mol_list, self._thermal_dump_path)
+                logger.info(f"density matrix loaded:{ket_mpo}")
+            except FileNotFoundError:
+                logger.debug(f"no file found in {self._thermal_dump_path}")
+                tp.evolve(None, self.insteps, self.temperature.to_beta() / 2j)
+                ket_mpo = tp.latest_mps
+                ket_mpo.dump(self._thermal_dump_path)
+        else:
+            tp.evolve(None, self.insteps, self.temperature.to_beta() / 2j)
+            ket_mpo = tp.latest_mps
         ket_mpo.evolve_config = self.evolve_config
         # e^{\-beta H/2} \Psi
         dipole_mpo_dagger = dipole_mpo.conj_trans()
@@ -59,6 +100,27 @@ class SpectraFiniteT(SpectraTdMpsJobBase):
         a_ket_mpo.canonical_normalize()
         a_bra_mpo = a_ket_mpo.copy()
         return BraKetPairEmiFiniteT(a_bra_mpo, a_ket_mpo)
+
+    @property
+    def _thermal_dump_path(self):
+        assert self._defined_output_path
+        return os.path.join(self.dump_dir, self.job_name + "_impo.npz")
+
+    def get_dump_dict(self):
+        dump_dict = dict()
+        dump_dict['temperature'] = self.temperature.as_au()
+        dump_dict['time series'] = self.evolve_times
+        dump_dict['autocorr_real'] = cast_float(self.autocorr.real)
+        dump_dict['autocorr_imag'] = cast_float(self.autocorr.imag)
+        return dump_dict
+
+    def stop_evolve_criteria(self):
+        corr = self.autocorr
+        if len(corr) < 10:
+            return False
+        last_corr = corr[-10:]
+        first_corr = corr[0]
+        return np.abs(last_corr.mean()) < 1e-5 * np.abs(first_corr) and last_corr.std() < 1e-5 * np.abs(first_corr)
 
     def init_mps_abs(self):
         dipole_mpo = Mpo.onsite(self.mol_list, r"a^\dagger", dipole=True)
@@ -76,9 +138,11 @@ class SpectraFiniteT(SpectraTdMpsJobBase):
     def evolve_single_step(self, evolve_dt):
         latest_bra_mpo, latest_ket_mpo = self.latest_mps
         if len(self.evolve_times) % 2 == 1:
-            latest_ket_mpo = latest_ket_mpo.evolve_exact(self.h_mpo, -evolve_dt, "GS")
+            latest_ket_mpo = \
+                latest_ket_mpo.evolve_exact(self.h_mpo, -evolve_dt, "GS")
             latest_ket_mpo = latest_ket_mpo.evolve(self.h_mpo, evolve_dt)
         else:
-            latest_bra_mpo = latest_bra_mpo.evolve_exact(self.h_mpo, evolve_dt, "GS")
+            latest_bra_mpo = \
+                latest_bra_mpo.evolve_exact(self.h_mpo, evolve_dt, "GS")
             latest_bra_mpo = latest_bra_mpo.evolve(self.h_mpo, -evolve_dt)
         return self.latest_mps.__class__(latest_bra_mpo, latest_ket_mpo)


### PR DESCRIPTION
follow what `transport/autocorr.py` did, I made small changes for `spectra/finitet.py`:
- enable compress _config input for imaginary/real time evolution of finiteT emission 
- enable dump imaginary time evolution information for analysis
- read existing ket_mpo
- dump real time evolution auto-correlation after each step evolve
- add stop_criteira for real time evolution