### PR TITLE
Drastic refactor backend to save GPU memory

### DIFF
--- a/renormalizer/cv/finitet.py
+++ b/renormalizer/cv/finitet.py
@@ -320,7 +320,7 @@ class SpectraFtCV(SpectraCv):
             x, info = scipy.sparse.linalg.cg(
                 mata, vecb, tol=1.e-5, x0=guess, maxiter=500, M=M, atol=0)
         # logger.info(f"linear eq dim: {nonzeros}")
-        # logger.info(f'times for hop:{count[0]}')
+        # logger.info(f'times for hop:{count}')
         self.hop_time.append(count)
         if info != 0:
             logger.warning(

--- a/renormalizer/cv/finitet.py
+++ b/renormalizer/cv/finitet.py
@@ -6,10 +6,11 @@ from renormalizer.mps.matrix import (
     Matrix,
     multi_tensor_contract,
     tensordot,
-    ones,
     moveaxis
 )
 from renormalizer.cv.spectra_cv import SpectraCv
+from renormalizer.mps.backend import np, xp
+from renormalizer.mps.matrix import asxp, asnumpy
 from renormalizer.mps import (Mpo, svd_qn, MpDm, ThermalProp)
 from renormalizer.mps.lib import update_cv
 from renormalizer.utils import (
@@ -19,7 +20,6 @@ from renormalizer.utils import (
 import copy
 import os
 import logging
-import numpy as np
 import scipy
 
 logger = logging.getLogger(__name__)
@@ -168,24 +168,24 @@ class SpectraFtCV(SpectraCv):
 
         if self.method == "1site":
             add_list = [isite - 1]
-            first_L = first_LR[isite - 1]
-            first_R = first_LR[isite]
-            second_L = second_LR[isite - 1]
-            second_R = second_LR[isite]
-            third_L = third_LR[isite - 1]
-            third_R = third_LR[isite]
-            forth_L = forth_LR[isite - 1]
-            forth_R = forth_LR[isite]
+            first_L =  asxp(first_LR[isite - 1])
+            first_R =  asxp(first_LR[isite])
+            second_L = asxp(second_LR[isite - 1])
+            second_R = asxp(second_LR[isite])
+            third_L =  asxp(third_LR[isite - 1])
+            third_R =  asxp(third_LR[isite])
+            forth_L =  asxp(forth_LR[isite - 1])
+            forth_R =  asxp(forth_LR[isite])
         else:
             add_list = [isite - 2, isite - 1]
-            first_L = first_LR[isite - 2]
-            first_R = first_LR[isite]
-            second_L = second_LR[isite - 2]
-            second_R = second_LR[isite]
-            third_L = third_LR[isite - 2]
-            third_R = third_LR[isite]
-            forth_L = forth_LR[isite - 2]
-            forth_R = forth_LR[isite]
+            first_L =  asxp(first_LR[isite - 2])
+            first_R =  asxp(first_LR[isite])
+            second_L = asxp(second_LR[isite - 2])
+            second_R = asxp(second_LR[isite])
+            third_L =  asxp(third_LR[isite - 2])
+            third_R =  asxp(third_LR[isite])
+            forth_L =  asxp(forth_LR[isite - 2])
+            forth_R =  asxp(forth_LR[isite])
 
         xqnmat, xqnbigl, xqnbigr, xshape = \
             self.construct_X_qnmat(add_list, direction)
@@ -222,46 +222,49 @@ class SpectraFtCV(SpectraCv):
                 path_4, forth_L,
                 moveaxis(self.a_ket_mpo[isite - 1], (1, 2), (2, 1)),
                 forth_R)
-            vecb = - self.eta * vecb.asnumpy()
+            vecb = - self.eta * vecb
 
+        a_oper_isite = asxp(self.a_oper[isite - 1])
+        b_oper_isite = asxp(self.b_oper[isite - 1])
+        h_mpo_isite = asxp(self.h_mpo[isite - 1])
         # construct preconditioner
-        Idt = np.identity(self.h_mpo[isite - 1].shape[1])
-        M1_1 = np.einsum('aea->ae', first_L)
-        M1_2 = np.einsum('eccf->ecf', self.a_oper[isite - 1])
-        M1_3 = np.einsum('dfd->df', first_R)
-        M1_4 = np.einsum('bb->b', Idt)
+        Idt = xp.identity(h_mpo_isite.shape[1])
+        M1_1 = xp.einsum('aea->ae', first_L)
+        M1_2 = xp.einsum('eccf->ecf', a_oper_isite)
+        M1_3 = xp.einsum('dfd->df', first_R)
+        M1_4 = xp.einsum('bb->b', Idt)
         path_m1 = [([0, 1], "ae,b->aeb"),
                    ([2, 0], "aeb,ecf->abcf"),
                    ([1, 0], "abcf, df->abcd")]
         pre_M1 = multi_tensor_contract(
-            path_m1, Matrix(M1_1), Matrix(M1_4), Matrix(M1_2), Matrix(M1_3))
-        pre_M1 = pre_M1.asnumpy()[
+            path_m1, M1_1, M1_4, M1_2, M1_3)
+        pre_M1 = pre_M1[
             self.condition(dag_qnmat, [down_exciton, up_exciton])]
 
-        M2_1 = np.einsum('aeag->aeg', second_L)
-        M2_2 = np.einsum('eccf->ecf', self.b_oper[isite-1])
-        M2_3 = np.einsum('gbbh->gbh', self.h_mpo[isite-1])
-        M2_4 = np.einsum('dfdh->dfh', second_R)
+        M2_1 = xp.einsum('aeag->aeg', second_L)
+        M2_2 = xp.einsum('eccf->ecf', b_oper_isite)
+        M2_3 = xp.einsum('gbbh->gbh', h_mpo_isite)
+        M2_4 = xp.einsum('dfdh->dfh', second_R)
         path_m2 = [([0, 1], "aeg,gbh->aebh"),
                    ([2, 0], "aebh,ecf->abchf"),
                    ([1, 0], "abhcf,dfh->abcd")]
         pre_M2 = multi_tensor_contract(
-            path_m2, Matrix(M2_1), Matrix(M2_3), Matrix(M2_2), Matrix(M2_4))
-        pre_M2 = pre_M2.asnumpy()[
+            path_m2, M2_1, M2_3, M2_2, M2_4)
+        pre_M2 = pre_M2[
             self.condition(dag_qnmat, [down_exciton, up_exciton])]
 
-        M4_1 = np.einsum('faah->fah', third_L)
-        M4_4 = np.einsum('gddi->gdi', third_R)
-        M4_5 = np.einsum('cc->c', Idt)
+        M4_1 = xp.einsum('faah->fah', third_L)
+        M4_4 = xp.einsum('gddi->gdi', third_R)
+        M4_5 = xp.einsum('cc->c', Idt)
         M4_path = [([0, 1], "fah,febg->ahebg"),
                    ([2, 0], "ahebg,hjei->abgji"),
                    ([1, 0], "abgji,gdi->abjd")]
         pre_M4 = multi_tensor_contract(
-            M4_path, Matrix(M4_1), self.h_mpo[isite-1],
-            self.h_mpo[isite-1], Matrix(M4_4))
-        pre_M4 = np.einsum('abbd->abd', pre_M4.asnumpy())
-        pre_M4 = np.tensordot(pre_M4, M4_5, axes=0)
-        pre_M4 = np.moveaxis(pre_M4, [2, 3], [3, 2])[
+            M4_path, M4_1, h_mpo_isite,
+            h_mpo_isite, M4_4)
+        pre_M4 = xp.einsum('abbd->abd', pre_M4)
+        pre_M4 = xp.tensordot(pre_M4, M4_5, axes=0)
+        pre_M4 = xp.moveaxis(pre_M4, [2, 3], [3, 2])[
             self.condition(dag_qnmat, [down_exciton, up_exciton])]
 
         pre_M = (pre_M1 + 2 * pre_M2 + pre_M4)
@@ -274,26 +277,27 @@ class SpectraFtCV(SpectraCv):
         M_x = lambda x: scipy.sparse.linalg.spsolve(pre_M, x)
         M = scipy.sparse.linalg.LinearOperator((nonzeros, nonzeros), M_x)
 
-        count = [0]
+        count = 0
 
         def hop(x):
-            count[0] += 1
-            dag_struct = self.dag2mat(
-                xshape, x, dag_qnmat, direction)
+            nonlocal count
+            count += 1
+            dag_struct = asxp(self.dag2mat(
+                xshape, x, dag_qnmat, direction))
             if self.method == "1site":
-                #
+
                 M1 = multi_tensor_contract(
-                    path_1, first_L, Matrix(dag_struct),
-                    self.a_oper[isite - 1], first_R)
+                    path_1, first_L, dag_struct,
+                    a_oper_isite, first_R)
                 M2 = multi_tensor_contract(
-                    path_2, second_L, Matrix(dag_struct),
-                    self.b_oper[isite - 1],
-                    self.h_mpo[isite - 1], second_R)
-                M2 = moveaxis(M2, (1, 2), (2, 1))
+                    path_2, second_L, dag_struct,
+                    b_oper_isite,
+                    h_mpo_isite, second_R)
+                M2 = xp.moveaxis(M2, (1, 2), (2, 1))
                 M3 = multi_tensor_contract(
-                    path_2, third_L, self.h_mpo[isite - 1], Matrix(dag_struct),
-                    self.h_mpo[isite - 1], third_R)
-                M3 = moveaxis(M3, (1, 2), (2, 1))
+                    path_2, third_L, h_mpo_isite, dag_struct,
+                    h_mpo_isite, third_R)
+                M3 = xp.moveaxis(M3, (1, 2), (2, 1))
                 cout = M1 + 2 * M2 + M3
             cout = cout[
                 self.condition(dag_qnmat, [down_exciton, up_exciton])
@@ -301,7 +305,7 @@ class SpectraFtCV(SpectraCv):
             return cout
 
         # Matrix A and Vector b
-        vecb = vecb[
+        vecb = asnumpy(vecb)[
             self.condition(dag_qnmat, [down_exciton, up_exciton])
         ].reshape(nonzeros, 1)
         mata = scipy.sparse.linalg.LinearOperator((nonzeros, nonzeros),
@@ -317,7 +321,7 @@ class SpectraFtCV(SpectraCv):
                 mata, vecb, tol=1.e-5, x0=guess, maxiter=500, M=M, atol=0)
         # logger.info(f"linear eq dim: {nonzeros}")
         # logger.info(f'times for hop:{count[0]}')
-        self.hop_time.append(count[0])
+        self.hop_time.append(count)
         if info != 0:
             logger.warning(
                 f"cg not converged, vecb.norm:{np.linalg.norm(vecb)}")
@@ -629,46 +633,46 @@ class SpectraFtCV(SpectraCv):
 
     def initialize_LR(self, direction):
 
-        first_LR = [ones((1, 1, 1))]
-        second_LR = [ones((1, 1, 1, 1))]
-        forth_LR = [ones((1, 1))]
+        first_LR = [np.ones((1, 1, 1))]
+        second_LR = [np.ones((1, 1, 1, 1))]
+        forth_LR = [np.ones((1, 1))]
         for isite in range(1, len(self.cv_mpo)):
             first_LR.append(None)
             second_LR.append(None)
             forth_LR.append(None)
-        first_LR.append(ones((1, 1, 1)))
-        second_LR.append(ones((1, 1, 1, 1)))
+        first_LR.append(np.ones((1, 1, 1)))
+        second_LR.append(np.ones((1, 1, 1, 1)))
         third_LR = copy.deepcopy(second_LR)
-        forth_LR.append(ones((1, 1)))
+        forth_LR.append(np.ones((1, 1)))
 
         if direction == "right":
             for isite in range(len(self.cv_mpo), 1, -1):
                 path1 = [([0, 1], "abc, defa -> bcdef"),
                          ([2, 0], "bcdef, gfhb -> cdegh"),
                          ([1, 0], "cdegh, ihec -> dgi")]
-                first_LR[isite - 1] = multi_tensor_contract(
+                first_LR[isite - 1] = asnumpy(multi_tensor_contract(
                     path1, first_LR[isite],
                     moveaxis(self.cv_mpo[isite - 1], (1, 2), (2, 1)),
-                    self.a_oper[isite - 1], self.cv_mpo[isite - 1])
+                    self.a_oper[isite - 1], self.cv_mpo[isite - 1]))
                 path2 = [([0, 1], "abcd, efga -> bcdefg"),
                          ([3, 0], "bcdefg, hgib -> cdefhi"),
                          ([2, 0], "cdefhi, jikc -> defhjk"),
                          ([1, 0], "defhjk, lkfd -> ehjl")]
                 path4 = [([0, 1], "ab, cdea->bcde"),
                          ([1, 0], "bcde, fedb->cf")]
-                second_LR[isite - 1] = multi_tensor_contract(
+                second_LR[isite - 1] = asnumpy(multi_tensor_contract(
                     path2, second_LR[isite],
                     moveaxis(self.cv_mpo[isite - 1], (1, 2), (2, 1)),
                     self.b_oper[isite - 1], self.cv_mpo[isite - 1],
-                    self.h_mpo[isite - 1])
-                third_LR[isite - 1] = multi_tensor_contract(
+                    self.h_mpo[isite - 1]))
+                third_LR[isite - 1] = asnumpy(multi_tensor_contract(
                     path2, third_LR[isite], self.h_mpo[isite - 1],
                     moveaxis(self.cv_mpo[isite - 1], (1, 2), (2, 1)),
-                    self.cv_mpo[isite - 1], self.h_mpo[isite - 1])
-                forth_LR[isite - 1] = multi_tensor_contract(
+                    self.cv_mpo[isite - 1], self.h_mpo[isite - 1]))
+                forth_LR[isite - 1] = asnumpy(multi_tensor_contract(
                     path4, forth_LR[isite],
                     moveaxis(self.a_ket_mpo[isite - 1], (1, 2), (2, 1)),
-                    self.cv_mpo[isite - 1])
+                    self.cv_mpo[isite - 1]))
 
         if direction == "left":
 
@@ -676,29 +680,29 @@ class SpectraFtCV(SpectraCv):
                 path1 = [([0, 1], "abc, adef -> bcdef"),
                          ([2, 0], "bcdef, begh -> cdfgh"),
                          ([1, 0], "cdfgh, cgdi -> fhi")]
-                first_LR[isite] = multi_tensor_contract(
+                first_LR[isite] = asnumpy(multi_tensor_contract(
                     path1, first_LR[isite - 1],
                     moveaxis(self.cv_mpo[isite - 1], (1, 2), (2, 1)),
-                    self.a_oper[isite - 1], self.cv_mpo[isite - 1])
+                    self.a_oper[isite - 1], self.cv_mpo[isite - 1]))
                 path2 = [([0, 1], "abcd, aefg -> bcdefg"),
                          ([3, 0], "bcdefg, bfhi -> cdeghi"),
                          ([2, 0], "cdeghi, chjk -> degijk"),
                          ([1, 0], "degijk, djel -> gikl")]
                 path4 = [([0, 1], "ab, acde->bcde"),
                          ([1, 0], "bcde, bdcf->ef")]
-                second_LR[isite] = multi_tensor_contract(
+                second_LR[isite] = asnumpy(multi_tensor_contract(
                     path2, second_LR[isite - 1],
                     moveaxis(self.cv_mpo[isite - 1], (1, 2), (2, 1)),
                     self.b_oper[isite - 1], self.cv_mpo[isite - 1],
-                    self.h_mpo[isite - 1])
-                third_LR[isite] = multi_tensor_contract(
+                    self.h_mpo[isite - 1]))
+                third_LR[isite] = asnumpy(multi_tensor_contract(
                     path2, third_LR[isite - 1], self.h_mpo[isite - 1],
                     moveaxis(self.cv_mpo[isite - 1], (1, 2), (2, 1)),
-                    self.cv_mpo[isite - 1], self.h_mpo[isite - 1])
-                forth_LR[isite] = multi_tensor_contract(
+                    self.cv_mpo[isite - 1], self.h_mpo[isite - 1]))
+                forth_LR[isite] = asnumpy(multi_tensor_contract(
                     path4, forth_LR[isite - 1],
                     moveaxis(self.a_ket_mpo[isite - 1], (1, 2), (2, 1)),
-                    self.cv_mpo[isite - 1])
+                    self.cv_mpo[isite - 1]))
         return [first_LR, second_LR, third_LR, forth_LR]
 
     def update_LR(self, lr_group, direction, isite):
@@ -761,8 +765,8 @@ class SpectraFtCV(SpectraCv):
                     moveaxis(self.a_ket_mpo[isite - 1], (1, 2), (2, 1)),
                     self.cv_mpo[isite - 1])
         else:
-            pass
-        # 2site for finite temperature is too expensive, so I drop it
-        # (at least for now)
+            # 2site for finite temperature is too expensive, so I drop it
+            # (at least for now)
+            raise NotImplementedError
 
         return first_LR, second_LR, third_LR, forth_LR

--- a/renormalizer/cv/finitet.py
+++ b/renormalizer/cv/finitet.py
@@ -272,7 +272,7 @@ class SpectraFtCV(SpectraCv):
         indices = np.array(range(nonzeros))
         indptr = np.array(range(nonzeros+1))
         pre_M = scipy.sparse.csc_matrix(
-            (pre_M, indices, indptr), shape=(nonzeros, nonzeros))
+            (asnumpy(pre_M), indices, indptr), shape=(nonzeros, nonzeros))
 
         M_x = lambda x: scipy.sparse.linalg.spsolve(pre_M, x)
         M = scipy.sparse.linalg.LinearOperator((nonzeros, nonzeros), M_x)
@@ -302,7 +302,7 @@ class SpectraFtCV(SpectraCv):
             cout = cout[
                 self.condition(dag_qnmat, [down_exciton, up_exciton])
             ].reshape(nonzeros, 1)
-            return cout
+            return asnumpy(cout)
 
         # Matrix A and Vector b
         vecb = asnumpy(vecb)[

--- a/renormalizer/cv/spectra_cv.py
+++ b/renormalizer/cv/spectra_cv.py
@@ -128,8 +128,11 @@ class SpectraCv(object):
     def oper_prepare(self, omega):
         raise NotImplementedError
 
-    def initialize_LR(self, direction):
-        raise NotImplemented
+    def optimize_cv(self, lr_group, direction, isite, num, percent=0):
+        raise NotImplementedError
 
-    def update_LR(self, direction):
-        raise NotImplemented
+    def initialize_LR(self, direction):
+        raise NotImplementedError
+
+    def update_LR(self, lrgroup, direction, isite):
+        raise NotImplementedError

--- a/renormalizer/cv/spectra_cv.py
+++ b/renormalizer/cv/spectra_cv.py
@@ -3,6 +3,7 @@
 # correction vector base
 import numpy as np
 from multiprocessing import Pool
+import multiprocessing
 from renormalizer.mps import Mpo
 from renormalizer.utils import Quantity
 from renormalizer.utils.elementop import construct_e_op_dict, ph_op_matrix
@@ -48,18 +49,22 @@ class SpectraCv(object):
         print('Quantum number of X', check_1)
     '''
     def run(self):
-        start = time.time()
-        pool = Pool(processes=self.cores)
-        logger.info(f"{len(self.freq_reg)} total frequency to do")
-        logger.info(f"{self.cores} multiprocess parallelization activated")
-        freq_reg = self.freq_reg
-        spectra = []
-        for i_spec in pool.imap(
-                unwrap_self, zip([self]*len(freq_reg), freq_reg)
-        ):
-            spectra.append(i_spec)
-        logger.info(f"time used:{time.time()-start}")
-        return spectra
+        try:
+            multiprocessing.set_start_method('forkserver', force=True)
+            start = time.time()
+            pool = Pool(processes=self.cores)
+            logger.info(f"{len(self.freq_reg)} total frequency to do")
+            logger.info(f"{self.cores} multiprocess parallelization activated")
+            freq_reg = self.freq_reg
+            spectra = []
+            for i_spec in pool.imap(
+                    unwrap_self, zip([self]*len(freq_reg), freq_reg)
+            ):
+                spectra.append(i_spec)
+            logger.info(f"time used:{time.time()-start}")
+            return spectra
+        except RuntimeError:
+            pass
 
     def cv_solve(self, omega):
         self.hop_time = []

--- a/renormalizer/cv/zerot.py
+++ b/renormalizer/cv/zerot.py
@@ -195,7 +195,7 @@ class SpectraZtCV(SpectraCv):
                 'aba, bccd, deef, gfg->aceg', first_L, a_oper_isite2,
                 a_oper_isite1, first_R)[qnmat == constrain_qn]
 
-        pre_a_mat = np.diag(1./pre_a_mat)
+        pre_a_mat = np.diag(1./asnumpy(pre_a_mat))
 
         count = 0
         def hop(c):
@@ -235,7 +235,7 @@ class SpectraZtCV(SpectraCv):
         # the value of the functional L
         l_value = np.inner(hop(x).reshape(1, nonzeros), x.reshape(1, nonzeros)
                      ) - 2 * np.inner(
-                         vec_b.reshape(1, nonzeros), x.reshape(1, nonzeros))
+                         asnumpy(vec_b).reshape(1, nonzeros), x.reshape(1, nonzeros))
         xstruct = svd_qn.cvec2cmat(xshape, x, qnmat, constrain_qn)
         x, xdim, xqn, compx = \
             solver.renormalization_svd(xstruct, qnbigl, qnbigr, system,

--- a/renormalizer/cv/zerot.py
+++ b/renormalizer/cv/zerot.py
@@ -13,6 +13,7 @@ from renormalizer.mps.matrix import (
     multi_tensor_contract,
 )
 from renormalizer.mps.solver import construct_mps_mpo_2, optimize_mps
+from renormalizer.utils import OptimizeConfig
 import logging
 import scipy
 import copy
@@ -96,7 +97,7 @@ class SpectraZtCV(SpectraCv):
                 self.mol_list, self.procedure_gs[0][0], self.nexciton
             )
         # ground state calculation
-        mps.optimize_config.procdure = self.procedure_gs
+        mps.optimize_config = OptimizeConfig(procedure=self.procedure_gs)
         mps.optimize_config.method = "2site"
         self.lowest_e = optimize_mps(mps, self.mpo)
         ket_mps = dipole_mpo.apply(mps, canonicalise=True)

--- a/renormalizer/cv/zerot.py
+++ b/renormalizer/cv/zerot.py
@@ -40,6 +40,7 @@ class SpectraZtCV(SpectraCv):
         procedure_gs : list, optional
             the procedure for ground state calculation
             if not provided, procedure_gs = [[10, 0.4], [20, 0.2], [30, 0.1], [40, 0], [40, 0]]
+            warning: the default one won't be enough for large systems!
         procedure_cv : list
             percent used for each sweep
         cores : int

--- a/renormalizer/cv/zerot.py
+++ b/renormalizer/cv/zerot.py
@@ -4,17 +4,16 @@
 
 
 from renormalizer.cv.spectra_cv import SpectraCv
+from renormalizer.mps.backend import np, xp
 from renormalizer.mps import Mpo, Mps, solver, svd_qn
-from renormalizer.mps.solver import construct_mps_mpo_2, optimize_mps
 from renormalizer.mps.matrix import (
-    Matrix,
+    asnumpy,
+    asxp,
     tensordot,
     multi_tensor_contract,
-    ones,
-    einsum
 )
+from renormalizer.mps.solver import construct_mps_mpo_2, optimize_mps
 import logging
-import numpy as np
 import scipy
 import copy
 
@@ -136,16 +135,16 @@ class SpectraZtCV(SpectraCv):
 
         if self.method == "1site":
             addlist = [isite - 1]
-            first_L = first_LR[isite - 1]
-            first_R = first_LR[isite]
-            second_L = second_LR[isite - 1]
-            second_R = second_LR[isite]
+            first_L =  asxp(first_LR[isite - 1])
+            first_R =  asxp(first_LR[isite])
+            second_L = asxp(second_LR[isite - 1])
+            second_R = asxp(second_LR[isite])
         else:
             addlist = [isite - 2, isite - 1]
-            first_L = first_LR[isite - 2]
-            first_R = first_LR[isite]
-            second_L = second_LR[isite - 2]
-            second_R = second_LR[isite]
+            first_L =  asxp(first_LR[isite - 2])
+            first_R =  asxp(first_LR[isite])
+            second_L = asxp(second_LR[isite - 2])
+            second_R = asxp(second_LR[isite])
 
         if direction == 'left':
             system = 'R'
@@ -179,48 +178,55 @@ class SpectraZtCV(SpectraCv):
                 self.b_oper[isite - 1], second_R
             )[qnmat == constrain_qn].reshape(nonzeros, 1)
 
-        count = [0]
+        if self.method == "2site":
+            a_oper_isite2 = asxp(self.a_oper[isite - 2])
+        else:
+            a_oper_isite2 = None
+        a_oper_isite1 = asxp(self.a_oper[isite - 1])
+
         # use the diagonal part of mat_a to construct the preconditinoner for linear solver
         if self.method == "1site":
-            pre_a_mat = einsum('aba, bccd, ede->ace', first_L, self.a_oper[isite - 1],
+            pre_a_mat = xp.einsum('aba, bccd, ede->ace', first_L, a_oper_isite1,
                            first_R)[qnmat == constrain_qn]
         else:
-            pre_a_mat = einsum(
-                'aba, bccd, deef, gfg->aceg', first_L, self.a_oper[isite - 2],
+            pre_a_mat = xp.einsum(
+                'aba, bccd, deef, gfg->aceg', first_L, a_oper_isite2,
                 self.a_oper[isite - 1], first_R)[qnmat == constrain_qn]
 
-        pre_a_mat = np.diag(1./pre_a_mat.asnumpy())
+        pre_a_mat = np.diag(1./pre_a_mat)
 
+        count = 0
         def hop(c):
-            count[0] += 1
-            xstruct = svd_qn.cvec2cmat(xshape, c, qnmat, constrain_qn)
+            nonlocal count
+            count += 1
+            xstruct = asxp(svd_qn.cvec2cmat(xshape, c, qnmat, constrain_qn))
             if self.method == "1site":
                 path_a = [([0, 1], "abc, ade->bcde"),
                           ([2, 0], "bcde, bdfg->cefg"),
                           ([1, 0], "cefg, egh->cfh")]
-                ax = multi_tensor_contract(path_a, first_L, Matrix(xstruct),
-                                           self.a_oper[isite - 1], first_R)
+                ax = multi_tensor_contract(path_a, first_L, xstruct,
+                                           a_oper_isite1, first_R)
             else:
                 path_a = [([0, 1], "abc, adef->bcdef"),
                           ([3, 0], "bcdef, bdgh->cefgh"),
                           ([2, 0], "cefgh, heij->cfgij"),
                           ([1, 0], "cfgij, fjk->cgik")]
-                ax = multi_tensor_contract(path_a, first_L, Matrix(xstruct),
-                                           self.a_oper[isite - 2], self.a_oper[isite - 1],
+                ax = multi_tensor_contract(path_a, first_L, xstruct,
+                                           a_oper_isite2, a_oper_isite1,
                                            first_R)
-            cout = ax[qnmat == constrain_qn].reshape(nonzeros, 1).asnumpy()
-            return cout
+            cout = ax[qnmat == constrain_qn].reshape(nonzeros, 1)
+            return asnumpy(cout)
 
         mat_a = scipy.sparse.linalg.LinearOperator((nonzeros, nonzeros), matvec=hop)
         # for the first two sweep, not use the previous matrix as initial guess
         # at the inital stage, they are far from from the optimized one
         if num in [1, 2]:
-            x, info = scipy.sparse.linalg.cg(mat_a, vec_b.asnumpy(), atol=0)
+            x, info = scipy.sparse.linalg.cg(mat_a, asnumpy(vec_b), atol=0)
         else:
-            x, info = scipy.sparse.linalg.cg(mat_a, vec_b.asnumpy(), tol=1.e-5,
+            x, info = scipy.sparse.linalg.cg(mat_a, asnumpy(vec_b), tol=1.e-5,
                                              x0=guess, M=pre_a_mat, atol=0)
-        # logger.info(f'hop times:{count[0]}')
-        self.hop_time.append(count[0])
+        # logger.info(f'hop times:{count}')
+        self.hop_time.append(count)
         if info != 0:
             logger.info(f"iteration solver not converged")
 
@@ -268,38 +274,39 @@ class SpectraZtCV(SpectraCv):
     def initialize_LR(self, direction):
         # initialize the Lpart and Rpart
         first_LR = []
-        first_LR.append(ones((1, 1, 1)))
+        first_LR.append(np.ones((1, 1, 1)))
         second_LR = []
-        second_LR.append(ones((1, 1)))
+        second_LR.append(np.ones((1, 1)))
         for isite in range(1, len(self.cv_mps)):
             first_LR.append(None)
             second_LR.append(None)
-        first_LR.append(ones((1, 1, 1)))
-        second_LR.append(ones((1, 1)))
+        first_LR.append(np.ones((1, 1, 1)))
+        second_LR.append(np.ones((1, 1)))
         if direction == "right":
             for isite in range(len(self.cv_mps), 1, -1):
                 path1 = [([0, 1], "abc, dea->bcde"),
                          ([2, 0], "bcde, fegb->cdfg"),
                          ([1, 0], "cdfg, hgc->dfh")]
-                first_LR[isite - 1] = multi_tensor_contract(
+                first_LR[isite - 1] = asnumpy(multi_tensor_contract(
                     path1, first_LR[isite], self.cv_mps[isite - 1],
-                    self.a_oper[isite - 1], self.cv_mps[isite - 1])
+                    self.a_oper[isite - 1], self.cv_mps[isite - 1]))
                 path2 = [([0, 1], "ab, cda->bcd"),
                          ([1, 0], "bcd, edb->ce")]
-                second_LR[isite - 1] = multi_tensor_contract(
-                    path2, second_LR[isite], self.b_oper[isite - 1], self.cv_mps[isite - 1])
+                second_LR[isite - 1] = asnumpy(multi_tensor_contract(
+                    path2, second_LR[isite], self.b_oper[isite - 1], self.cv_mps[isite - 1]))
         else:
             for isite in range(1, len(self.cv_mps)):
+                mps_isite = asxp(self.cv_mps[isite - 1])
                 path1 = [([0, 1], "abc, ade->bcde"),
                          ([2, 0], "bcde, bdfg->cefg"),
                          ([1, 0], "cefg, cfh->egh")]
-                first_LR[isite] = multi_tensor_contract(
-                    path1, first_LR[isite - 1], self.cv_mps[isite - 1],
-                    self.a_oper[isite - 1], self.cv_mps[isite - 1])
+                first_LR[isite] = asnumpy(multi_tensor_contract(
+                    path1, first_LR[isite - 1], mps_isite,
+                    self.a_oper[isite - 1], self.cv_mps[isite - 1]))
                 path2 = [([0, 1], "ab, acd->bcd"),
                          ([1, 0], "bcd, bce->de")]
-                second_LR[isite] = multi_tensor_contract(
-                    path2, second_LR[isite - 1], self.b_oper[isite - 1], self.cv_mps[isite - 1])
+                second_LR[isite] = asnumpy(multi_tensor_contract(
+                    path2, second_LR[isite - 1], self.b_oper[isite - 1], mps_isite))
         return [first_LR, second_LR]
 
     def update_LR(self, lr_group, direction, isite):

--- a/renormalizer/cv/zerot.py
+++ b/renormalizer/cv/zerot.py
@@ -191,7 +191,7 @@ class SpectraZtCV(SpectraCv):
         else:
             pre_a_mat = xp.einsum(
                 'aba, bccd, deef, gfg->aceg', first_L, a_oper_isite2,
-                self.a_oper[isite - 1], first_R)[qnmat == constrain_qn]
+                a_oper_isite1, first_R)[qnmat == constrain_qn]
 
         pre_a_mat = np.diag(1./pre_a_mat)
 

--- a/renormalizer/lib/integrate/_ivp/base.py
+++ b/renormalizer/lib/integrate/_ivp/base.py
@@ -160,7 +160,7 @@ class OdeSolver(object):
         if self.t_old is None:
             return None
         else:
-            return xp.abs(self.t - self.t_old)
+            return np.abs(self.t - self.t_old)
 
     def step(self):
         """Perform one integration step.
@@ -253,7 +253,7 @@ class DenseOutput(object):
             Computed values. Shape depends on whether `t` was a scalar or a
             1-d array.
         """
-        t = xp.asarray(t)
+        t = np.asarray(t)
         if t.ndim > 1:
             raise ValueError("`t` must be float or 1-d array.")
         return self._call_impl(t)
@@ -277,6 +277,6 @@ class ConstantDenseOutput(DenseOutput):
         if t.ndim == 0:
             return self.value
         else:
-            ret = xp.empty((self.value.shape[0], t.shape[0]))
+            ret = np.empty((self.value.shape[0], t.shape[0]))
             ret[:] = self.value[:, None]
             return ret

--- a/renormalizer/lib/integrate/_ivp/rk.py
+++ b/renormalizer/lib/integrate/_ivp/rk.py
@@ -9,9 +9,7 @@ from .common import (
     validate_first_step,
 )
 
-import numpy as np
-
-from renormalizer.mps.backend import xp, backend
+from renormalizer.mps.backend import np, xp, backend
 
 # Multiply steps computed from asymptotic behaviour of errors by this.
 SAFETY = 0.9

--- a/renormalizer/lib/krylov/krylov.py
+++ b/renormalizer/lib/krylov/krylov.py
@@ -54,6 +54,7 @@ def expm_krylov(Afunc, dt, vstart: xp.ndarray, block_size=50):
         if len(V) - 2 == j:
             V, old_V = xp.empty((len(V) + block_size, len(vstart)), dtype=vstart.dtype), V
             V[:len(old_V)] = old_V
+            del old_V
             alpha = np.concatenate([alpha, np.zeros(block_size)])
             beta = np.concatenate([beta, np.zeros(block_size)])
         w = Afunc(V[j])

--- a/renormalizer/mps/matrix.py
+++ b/renormalizer/mps/matrix.py
@@ -5,9 +5,7 @@ import weakref
 import logging
 from typing import List, Union
 
-import numpy as np
-
-from renormalizer.mps.backend import np, backend, xp, USE_GPU, xp as xp
+from renormalizer.mps.backend import np, backend, xp, USE_GPU
 
 logger = logging.getLogger(__name__)
 
@@ -113,7 +111,7 @@ class Matrix:
         """
         tensm = asxp(self.array.reshape([np.prod(self.shape[:-1]), self.shape[-1]]))
         s = tensm.T.conj() @ tensm
-        return xp.allclose(s, np.eye(s.shape[0]), rtol=rtol, atol=atol)
+        return xp.allclose(s, xp.eye(s.shape[0]), rtol=rtol, atol=atol)
 
     def check_rortho(self, rtol=1e-5, atol=1e-8):
         """
@@ -121,7 +119,7 @@ class Matrix:
         """
         tensm = asxp(self.array.reshape([self.shape[0], np.prod(self.shape[1:])]))
         s = tensm @ tensm.T.conj()
-        return xp.allclose(s, np.eye(s.shape[0]), rtol=rtol, atol=atol)
+        return xp.allclose(s, xp.eye(s.shape[0]), rtol=rtol, atol=atol)
 
     def to_complex(self):
         # `xp.array` always creates new array, so to_complex means copy, which is

--- a/renormalizer/mps/mp.py
+++ b/renormalizer/mps/mp.py
@@ -1,15 +1,11 @@
 # -*- coding: utf-8 -*-
 # Author: Jiajun Ren <jiajunren0522@gmail.com>
-from __future__ import absolute_import, division
 
-import inspect
 import logging
-import traceback
 from typing import List, Union
 
-import numpy as np
-
 from renormalizer.model import MolList, EphTable
+from renormalizer.mps.backend import np, xp
 from renormalizer.mps import svd_qn
 from renormalizer.mps.matrix import (
     einsum,
@@ -228,7 +224,7 @@ class MatrixProduct:
             return range(self.qnidx, last, -1)
 
     def _update_ms(
-        self, idx: int, u: Matrix, vt: Matrix, sigma=None, qnlset=None, qnrset=None, m_trunc=None
+        self, idx: int, u: np.ndarray, vt: np.ndarray, sigma=None, qnlset=None, qnrset=None, m_trunc=None
     ):
         if m_trunc is None:
             m_trunc = u.shape[1]
@@ -238,21 +234,21 @@ class MatrixProduct:
             # canonicalise, vt is not unitary
             if self.is_mpo:
                 if self.to_right:
-                    norm = vt.norm()
-                    u = Matrix(u.array * norm)
-                    vt = Matrix(vt.array / norm)
+                    norm = np.linalg.norm(vt)
+                    u *= norm
+                    vt /= norm
                 else:
-                    norm = u.norm()
-                    u = Matrix(u.array / norm)
-                    vt = Matrix(vt.array * norm)
+                    norm = np.linalg.norm(u)
+                    u /= norm
+                    vt *= norm
         else:
             sigma = sigma[:m_trunc]
             if (not self.is_mpo and self.to_right) or (self.is_mpo and not self.to_right):
-                vt = einsum("i, ij -> ij", sigma, vt)
+                vt = np.einsum("i, ij -> ij", sigma, vt)
             else:
-                u = einsum("ji, i -> ji", u, sigma)
+                u = np.einsum("ji, i -> ji", u, sigma)
         if self.to_right:
-            self[idx + 1] = tensordot(vt, self[idx + 1], axes=1)
+            self[idx + 1] = tensordot(vt, self[idx + 1].array, axes=1)
             ret_mpsi = u.reshape(
                 [u.shape[0] // self[idx].pdim_prod] + list(self[idx].pdim) + [m_trunc]
             )
@@ -260,7 +256,7 @@ class MatrixProduct:
                 self.qn[idx + 1] = qnlset[:m_trunc]
                 self.qnidx = idx + 1
         else:
-            self[idx - 1] = tensordot(self[idx - 1], u, axes=1)
+            self[idx - 1] = tensordot(self[idx - 1].array, u, axes=1)
             ret_mpsi = vt.reshape(
                 [m_trunc] + list(self[idx].pdim) + [vt.shape[1] // self[idx].pdim_prod]
             )
@@ -402,7 +398,7 @@ class MatrixProduct:
                 mt = mt.r_combine()
             qnbigl, qnbigr, _ = self._get_big_qn(idx)
             u, sigma, qnlset, v, sigma, qnrset = svd_qn.Csvd(
-                mt.asnumpy(),
+                mt.array,
                 qnbigl,
                 qnbigr,
                 self.qntot,
@@ -417,7 +413,7 @@ class MatrixProduct:
             else:
                 m_trunc = min(temp_m_trunc, len(sigma))
             self._update_ms(
-                idx, Matrix(u), Matrix(vt), Matrix(sigma), qnlset, qnrset, m_trunc
+                idx, u, vt, sigma, qnlset, qnrset, m_trunc
             )
 
         self._switch_direction()
@@ -437,7 +433,7 @@ class MatrixProduct:
             qnbigl, qnbigr, _ = self._get_big_qn(idx)
             system = "L" if self.to_right else "R"
             u, qnlset, v, qnrset = svd_qn.Csvd(
-                mt.asnumpy(),
+                mt.array,
                 qnbigl,
                 qnbigr,
                 self.qntot,
@@ -446,7 +442,7 @@ class MatrixProduct:
                 full_matrices=False,
             )
             self._update_ms(
-                idx, Matrix(u), Matrix(v.T), sigma=None, qnlset=qnlset, qnrset=qnrset
+                idx, u, v.T, sigma=None, qnlset=qnlset, qnrset=qnrset
             )
         # can't iter to idx == 0 or idx == self.site_num - 1
         if (not self.to_right and idx == 1) or (self.to_right and idx == self.site_num - 2):
@@ -462,30 +458,30 @@ class MatrixProduct:
             new_mp[idx] = mt.conj()
         return new_mp
 
-    def dot(self, other):
+    def dot(self, other: "MatrixProduct") -> complex:
         """
         dot product of two mps / mpo 
         """
 
         assert len(self) == len(other)
-        e0 = eye(1, 1)
+        e0 = xp.eye(1, 1)
         # for debugging. It has little computational cost anyway
         debug_t = []
         for mt1, mt2 in zip(self, other):
             # sum_x e0[:,x].m[x,:,:]
             debug_t.append(e0)
-            e0 = tensordot(e0, mt2, 1)
+            e0 = tensordot(e0, mt2.array, 1)
             # sum_ij e0[i,p,:] self[i,p,:]
             # note, need to flip a (:) index onto top,
             # therefore take transpose
             if mt1.ndim == 3:
-                e0 = tensordot(e0, mt1, ([0, 1], [0, 1])).T
+                e0 = tensordot(e0, mt1.array, ([0, 1], [0, 1])).T
             elif mt1.ndim == 4:
-                e0 = tensordot(e0, mt1, ([0, 1, 2], [0, 1, 2])).T
+                e0 = tensordot(e0, mt1.array, ([0, 1, 2], [0, 1, 2])).T
             else:
                 assert False
 
-        return e0[0, 0]
+        return complex(e0[0, 0])
 
     def angle(self, other):
         return abs(self.conj().dot(other))
@@ -533,13 +529,13 @@ class MatrixProduct:
             new_mp[i] = mt.to_complex(inplace)
         return new_mp
 
-    def distance(self, other):
+    def distance(self, other) -> float:
         l1 = self.conj().dot(self) 
         l2 = other.conj().dot(other)
         l1dotl2 = self.conj().dot(other)
         dis_square = (l1 + l2
             - l1dotl2
-            - l1dotl2.conj()).real 
+            - l1dotl2.conjugate()).real
         
         if dis_square < 0:
             assert dis_square/l1.real < 1e-8

--- a/renormalizer/mps/mpdm.py
+++ b/renormalizer/mps/mpdm.py
@@ -6,8 +6,8 @@ from typing import List
 import numpy as np
 import scipy.linalg
 
-from renormalizer.mps.backend import xp, backend
-from renormalizer.mps.matrix import tensordot, ones
+from renormalizer.mps.backend import xp
+from renormalizer.mps.matrix import tensordot, asnumpy
 from renormalizer.mps import Mpo, Mps
 from renormalizer.mps.tdh import unitary_propagation
 
@@ -79,7 +79,7 @@ class MpDmBase(Mps, Mpo):
             assert mt_self.shape[2] == mt_other.shape[1]
             # mt=np.einsum("apqb,cqrd->acprbd",mt_s,mt_o)
             mt = xp.moveaxis(
-                xp.tensordot(mt_self.array, mt_other.array, axes=([2], [1])),
+                tensordot(mt_self.array, mt_other.array, axes=([2], [1])),
                 [-3, -2],
                 [1, 3],
             )
@@ -120,7 +120,7 @@ class MpDm(MpDmBase):
         mpo = cls()
         mpo.mol_list = mps.mol_list
         for ms in mps:
-            mo = xp.zeros(tuple([ms.shape[0]] + [ms.shape[1]] * 2 + [ms.shape[2]]))
+            mo = np.zeros(tuple([ms.shape[0]] + [ms.shape[1]] * 2 + [ms.shape[2]]))
             for iaxis in range(ms.shape[1]):
                 mo[:, iaxis, iaxis, :] = ms[:, iaxis, :].array
             mpo.append(mo)
@@ -176,7 +176,7 @@ class MpDm(MpDmBase):
             copy = self.copy().canonicalise()
             copy.canonicalise(self.mol_list.e_idx())
             e_mo = copy[self.mol_list.e_idx()]
-            return tensordot(e_mo, e_mo.conj(), axes=((0, 2 ,3), (0, 2, 3))).asnumpy()[1:, 1:]
+            return asnumpy(tensordot(e_mo, e_mo.conj(), axes=((0, 2 ,3), (0, 2, 3)))[1:, 1:])
         else:
             assert False
 

--- a/renormalizer/mps/mpo.py
+++ b/renormalizer/mps/mpo.py
@@ -6,7 +6,7 @@ import scipy
 from renormalizer.model import MolList
 from renormalizer.model.ephtable import EphTable
 from renormalizer.mps.backend import xp
-from renormalizer.mps.matrix import moveaxis, tensordot, ones, EmptyMatrixError
+from renormalizer.mps.matrix import moveaxis, tensordot, asnumpy, EmptyMatrixError
 from renormalizer.mps.mp import MatrixProduct
 from renormalizer.mps import svd_qn
 from renormalizer.mps.lib import update_cv
@@ -538,11 +538,11 @@ class Mpo(MatrixProduct):
         mpo.mol_list = mol_list
         for imol, mol in enumerate(mol_list):
             if mol_list.scheme < 4:
-                mpo.append(xp.eye(2).reshape(1, 2, 2, 1))
+                mpo.append(np.eye(2).reshape(1, 2, 2, 1))
             elif mol_list.scheme == 4:
                 if len(mpo) == mol_list.e_idx():
                     n = mol_list.mol_num
-                    mpo.append(xp.eye(n+1).reshape(1, n+1, n+1, 1))
+                    mpo.append(np.eye(n+1).reshape(1, n+1, n+1, 1))
             else:
                 assert False
             iph = 0
@@ -565,7 +565,7 @@ class Mpo(MatrixProduct):
         Parameters:
             mol_list : MolList
                 the molecular information
-            opera: 
+            opera:
                 the operators such as {1:"a", 3:r"a^\dagger"}
             scale: Quantity
                 scalar to scale the mpo
@@ -576,7 +576,7 @@ class Mpo(MatrixProduct):
 
         for i in opera.keys():
             assert i in range(mol_list.mol_num)
-        
+
         mpo = cls()
         mpo.mol_list = mol_list
         mpo.qn = [[0]]
@@ -599,7 +599,7 @@ class Mpo(MatrixProduct):
             else:
                 mo[0, :, :, 0] = eop["Iden"]
                 mpo.qn.append(mpo.qn[-1])
-            
+
             mpo.append(mo)
             impo += 1
 
@@ -615,12 +615,12 @@ class Mpo(MatrixProduct):
                     impo += 1
         mpo.qnidx = len(mpo) - 1
         mpo.to_right = False
-        
+
         mpo.qntot = mpo.qn[-1][0]
         mpo.qn[-1] = [0]
 
         mpo.offset = Quantity(0.)
-        
+
         return mpo.scale(scale.as_au(), inplace=True)
 
 
@@ -719,10 +719,10 @@ class Mpo(MatrixProduct):
         mpo = cls()
         mpo.mol_list = mol_list
         for p in mol_list.pbond_list:
-            mpo.append(xp.eye(p).reshape(1, p, p, 1))
+            mpo.append(np.eye(p).reshape(1, p, p, 1))
         mpo.build_empty_qn()
         return mpo
-    
+
     #def _scheme5(self, mol_list: MolList, elocal_offset, offset):
     #    # electronic part is in the first site
     #    # [H_e, op1, op2, ..., opn, 0]
@@ -748,7 +748,7 @@ class Mpo(MatrixProduct):
     #            pdim = mol_list.mol_num + 1
     #        else:
     #            raise ValueError("scheme5 input space {space} is not in ['GS','EX','GS+EX']")
-    #            
+    #
     #    def get_marginal_phonon_mo(pdim, bdim, ph, iterm, phop):
     #        # [ w b^d b,  gw(b^d+b), I]
     #        mo = np.zeros((1, pdim, pdim, bdim))
@@ -771,14 +771,14 @@ class Mpo(MatrixProduct):
 
     #    nmol = mol_list.mol_num
 
-    #    mo_e = np.zeros((1, pdim, pdim, len(e_op_list)))                      
-    #    
+    #    mo_e = np.zeros((1, pdim, pdim, len(e_op_list)))
+    #
     #    # vibrational site link list
     #    # left-hand of electronic site
     #    [(mol.ph,iterm),]
 
-    #    for ph, iterm in enumerate(lvib_list): 
-    #        if 
+    #    for ph, iterm in enumerate(lvib_list):
+    #        if
     #    # right hand of electronic site
     #    [(mol.iph,iterm),]
 
@@ -1071,9 +1071,9 @@ class Mpo(MatrixProduct):
                         mo = np.zeros([mpo_dim[impo], pbond, pbond, mpo_dim[impo + 1]])
 
                         if rep == "star":
-                            bpbdagger = qbopera[imol]["bpbdagger" + str(iph)][
+                            bpbdagger = asnumpy(qbopera[imol]["bpbdagger" + str(iph)][
                                 iqb
-                            ].asnumpy()
+                            ])
 
                             mo[0, :, :, 0] = phop["Iden"]
                             mo[-1, :, :, 0] = (
@@ -1378,17 +1378,17 @@ class Mpo(MatrixProduct):
         dim = np.prod(self.pbond_list)
         if 20000 < dim:
             raise ValueError("operator too large")
-        res = ones((1, 1, 1, 1))
+        res = np.ones((1, 1, 1, 1))
         for mt in self:
             dim1 = res.shape[1] * mt.shape[1]
             dim2 = res.shape[2] * mt.shape[2]
             dim3 = mt.shape[-1]
-            res = tensordot(res, mt, axes=1).transpose((0, 1, 3, 2, 4, 5)).reshape(1, dim1, dim2, dim3)
+            res = np.tensordot(res, mt.array, axes=1).transpose((0, 1, 3, 2, 4, 5)).reshape(1, dim1, dim2, dim3)
         return res[0, :, :, 0]
 
     def is_hermitian(self):
         full = self.full_operator()
-        return xp.allclose(full.array.conj().T, full, atol=1e-7)
+        return np.allclose(full.conj().T, full, atol=1e-7)
 
     def __matmul__(self, other):
         return self.apply(other)

--- a/renormalizer/mps/supermpo.py
+++ b/renormalizer/mps/supermpo.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 from typing import List, Tuple
 
-
-import numpy as np
-
 from renormalizer.mps.matrix import EmptyMatrixError
 from renormalizer.mps.mpo import Mpo
 from renormalizer.mps.mpdm import MpDmFull

--- a/renormalizer/mps/svd_qn.py
+++ b/renormalizer/mps/svd_qn.py
@@ -43,7 +43,7 @@ def Csvd(
 ):
     """
     block svd the coefficient matrix (l, sigmal, sigmar, r) or (l,sigma,r)
-    according to the quantum number 
+    according to the quantum number
     ddm is the direct diagonalization the reduced density matrix
     """
 
@@ -218,13 +218,13 @@ def blockrecover(indices, U, dim):
 def cvec2cmat(cshape, c, qnmat, nexciton, nroots=1):
     # recover good quantum number vector c to matrix format
     if nroots == 1:
-        cstruct = xp.zeros(cshape, dtype=c.dtype)
-        xp.place(cstruct, qnmat == nexciton, c)
+        cstruct = np.zeros(cshape, dtype=c.dtype)
+        np.place(cstruct, qnmat == nexciton, c)
     else:
         cstruct = []
         for ic in c:
-            icstruct = xp.zeros(cshape, dtype=ic.dtype)
-            xp.place(icstruct, qnmat == nexciton, ic)
+            icstruct = np.zeros(cshape, dtype=ic.dtype)
+            np.place(icstruct, qnmat == nexciton, ic)
             cstruct.append(icstruct)
 
     return cstruct
@@ -234,7 +234,7 @@ def construct_qnmat(mps, ephtable, pbond, addlist, method, system):
     """
     construct the quantum number pattern, the structure is as the coefficient
     QN: quantum number list at each bond
-    ephtable : e-ph table 1 is electron and 0 is phonon 
+    ephtable : e-ph table 1 is electron and 0 is phonon
     pbond : physical pbond
     addlist : the sigma orbital set
     """

--- a/renormalizer/mps/svd_qn.py
+++ b/renormalizer/mps/svd_qn.py
@@ -3,10 +3,9 @@
 
 from __future__ import absolute_import, print_function, unicode_literals
 
-import numpy as np
 import scipy.linalg
 
-from renormalizer.mps.backend import xp
+from renormalizer.mps.backend import np
 
 
 def blockappend(
@@ -33,7 +32,7 @@ def blockappend(
 
 
 def Csvd(
-    cstruct: xp.ndarray,
+    cstruct: np.ndarray,
     qnbigl,
     qnbigr,
     nexciton,

--- a/renormalizer/mps/tests/test_mp.py
+++ b/renormalizer/mps/tests/test_mp.py
@@ -27,7 +27,7 @@ def test_save_load():
     os.remove(fname)
 
 
-def check_distance(a: Mps ,b: Mps):
+def check_distance(a: Mps, b: Mps):
     d1 = (a - b).dmrg_norm
     d2 = a.distance(b)
     a_array = a.full_wfn()
@@ -56,6 +56,6 @@ def test_environ():
     for i in range(len(mps)-1):
         l = environ.read("L", i)
         r = environ.read("R", i+1)
-        e = tensordot(l, r, axes=((0, 1, 2), (0, 1, 2))).asnumpy()
+        e = complex(tensordot(l, r, axes=((0, 1, 2), (0, 1, 2)))).real
         assert pytest.approx(e) == mps.expectation(mpo)
 

--- a/renormalizer/mps/tests/test_mpo.py
+++ b/renormalizer/mps/tests/test_mpo.py
@@ -30,11 +30,11 @@ def test_offset(scheme):
     mpo1 = Mpo(mlist)
     assert mpo1.is_hermitian()
     f1 = mpo1.full_operator()
-    evals1, _ = np.linalg.eigh(f1.asnumpy())
+    evals1, _ = np.linalg.eigh(f1)
     offset = Quantity(0.123)
     mpo2 = Mpo(mlist, offset=offset)
     f2 = mpo2.full_operator()
-    evals2, _ = np.linalg.eigh(f2.asnumpy())
+    evals2, _ = np.linalg.eigh(f2)
     assert np.allclose(evals1 - offset.as_au(), evals2)
 
 def test_identity():

--- a/renormalizer/mps/tests/test_mpproperty.py
+++ b/renormalizer/mps/tests/test_mpproperty.py
@@ -2,10 +2,10 @@
 # Author: Jiajun Ren <jiajunren0522@gmail.com>
 #         Weitang Li <liwt31@163.com>
 
-import numpy as np
 import pytest
 
 from renormalizer.mps import Mps, Mpo, MpDm, ThermalProp
+from renormalizer.mps.backend import np
 from renormalizer.tests.parameter import mol_list
 from renormalizer.utils import Quantity
 

--- a/renormalizer/transport/autocorr.py
+++ b/renormalizer/transport/autocorr.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 
 import logging
-import os
 
-import numpy as np
 import scipy.integrate
 
 from renormalizer.mps import MpDm, Mpo, BraKetPair, ThermalProp, load_thermal_state
+from renormalizer.mps.backend import np
 from renormalizer.mps.lib import compressed_sum
 from renormalizer.utils.constant import mobility2au
 from renormalizer.utils import TdMpsJob, Quantity, EvolveConfig, CompressConfig

--- a/renormalizer/transport/transport.py
+++ b/renormalizer/transport/transport.py
@@ -147,7 +147,7 @@ class ChargeTransport(TdMpsJob):
         # start from phonon
         for i, ph in enumerate(center_mol.dmrg_phs):
             idx = self.mol_list.ph_idx(center_mol_idx, i)
-            mt = gs_mp[idx][0, ..., 0].asnumpy()
+            mt = gs_mp[idx][0, ..., 0].array
             evecs = ph.get_displacement_evecs()
             if gs_mp.is_mps:
                 mt = evecs.dot(mt)


### PR DESCRIPTION
Previously in GPU backend we store all matrices in GPU and copy to host when necessary to achieve maximum speed. However, it turns out in GPU calculation total memory usage is the bottle-neck instead of host-device memory transfer.
In this PR I make a drastic change to the strategy: **matrices are always stored in host and are copied to GPU when necessary.**
The new strategy allows incredibly small memory usage when scheme <= 3 ( save up to 80% memory according to some tests) and has little effect on scheme4, in which the memory bottleneck is not storing MPSs but contraction intermediate results. The performance regression is well controlled, typically less than 20%, maybe more serious in VMF.
The new strategy also encourages the developers to use numpy or cupy ndarray directly instead of the `Matrix` class, which only stores matrices in host memory. Previously we usually use `Matrix(a)` to transfer matrix `a` to GPU memory. Now the correct way is `asxp(a)`. As a result, the developers should be ultra-careful regarding SP/DP because previously this is guaranteed in the `Matrix` class and now it is the responsibility of developers. For example, one should use things like
```
a = xp.ones((1,1,1), dtype=backend.real_dtype)
```
instead of 
```
a = xp.ones((1,1,1))
```
and the old way is
```
a = ones((1,1,1))
```

I've also updated codes in `cv` and they can work in CPU but they are not tested on GPU due to some unknown error. @jiangtong1000 you might want to know about the changes and review the cv code.