### PR TITLE
fix charge transport ft init bug

### DIFF
--- a/example/transport.py
+++ b/example/transport.py
@@ -35,12 +35,8 @@ if __name__ == "__main__":
         evolve_config=evolve_config,
         rdm=False,
     )
-    # ct.stop_at_edge = True
-    # ct.memory_limit = 2 ** 30  # 1 GB
-    # ct.memory_limit /= 10 # 100 MB
     ct.dump_dir = param["output dir"]
     ct.job_name = param["fname"]
     ct.custom_dump_info["comment"] = param["comment"]
-    # ct.latest_mps.compress_add = True
     ct.evolve(param.get("evolve dt"), param.get("nsteps"), param.get("evolve time"))
     # ct.evolve(evolve_dt, 100, param.get("evolve time"))

--- a/renormalizer/lib/krylov/krylov.py
+++ b/renormalizer/lib/krylov/krylov.py
@@ -21,10 +21,7 @@ def _expm_krylov(alpha, beta, V, v_norm, dt):
         h = np.diag(alpha) + np.diag(beta, k=-1) + np.diag(beta, k=1)
         w_hess, u_hess = np.linalg.eigh(h)
 
-    xp_w_hess = xp.array(w_hess)
-    xp_u_hess = xp.array(u_hess)
-
-    return V @ xp_u_hess @ (v_norm * xp.exp(dt*xp_w_hess) * xp_u_hess[0])
+    return V @ xp.asarray(u_hess @ (v_norm * np.exp(dt*w_hess) * u_hess[0]))
 
 
 def expm_krylov(Afunc, dt, vstart: xp.ndarray, block_size=50):
@@ -39,7 +36,7 @@ def expm_krylov(Afunc, dt, vstart: xp.ndarray, block_size=50):
 
     # normalize starting vector
     vstart = xp.asarray(vstart)
-    nrmv = xp.linalg.norm(vstart)
+    nrmv = float(xp.linalg.norm(vstart))
     assert nrmv > 0
     vstart = vstart / nrmv
 

--- a/renormalizer/transport/tests/test_transport.py
+++ b/renormalizer/transport/tests/test_transport.py
@@ -7,7 +7,7 @@ import os
 import pytest
 
 from renormalizer.model import Phonon, Mol, MolList
-from renormalizer.mps import Mps, Mpo
+from renormalizer.mps import Mps, Mpo, ThermalProp, MpDm, MpDmFull
 from renormalizer.mps.solver import optimize_mps
 from renormalizer.transport import ChargeTransport
 from renormalizer.utils import Quantity
@@ -26,7 +26,8 @@ from renormalizer.transport.tests.band_param import (
 
 import numpy as np
 
-def test_init_state():
+
+def test_zt_init_state():
     ph = Phonon.simple_phonon(Quantity(1), Quantity(1), 10)
     mol_list = MolList([Mol(Quantity(0), [ph])], Quantity(0), scheme=3)
     mpo = Mpo(mol_list)
@@ -34,6 +35,20 @@ def test_init_state():
     optimize_mps(mps, mpo)
     ct = ChargeTransport(mol_list)
     assert mps.angle(ct.latest_mps) == pytest.approx(1)
+
+
+def test_ft_init_state():
+    ph = Phonon.simple_phonon(Quantity(1), Quantity(1), 10)
+    mol_list = MolList([Mol(Quantity(0), [ph])], Quantity(0), scheme=3)
+    temperature = Quantity(0.1)
+    mpo = Mpo(mol_list)
+    init_mpdm = MpDm.max_entangled_ex(mol_list)
+    tp = ThermalProp(init_mpdm, mpo, space="EX", exact=True)
+    tp.evolve(nsteps=20, evolve_time=temperature.to_beta() / 2j)
+    ct = ChargeTransport(mol_list, temperature=temperature)
+    tp_mpdm = MpDmFull.from_mpdm(tp.latest_mps)
+    ct_mpdm = MpDmFull.from_mpdm(ct.latest_mps)
+    assert tp_mpdm.angle(ct_mpdm) == pytest.approx(1)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Previous code to create displaced phonon state at finite temperature actually does nothing:
```
mt = evecs.dot(evecs.T).dot(mt)
```
And the bug is fixed:
```
mt = evecs.dot(mt)
```
Other changes include some improvements in TDH and optimization in Krylov expm