### PR TITLE
optmize reduced density matrix calculation in scheme4

### DIFF
--- a/example/fmo.py
+++ b/example/fmo.py
@@ -157,7 +157,7 @@ if __name__ == "__main__":
     evolve_dt = 160
     evolve_config = EvolveConfig(EvolveMethod.tdvp_ps, guess_dt=evolve_dt)
     compress_config = CompressConfig(CompressCriteria.fixed, max_bonddim=32)
-    ct = ChargeTransport(mol_list, evolve_config=evolve_config, compress_config=compress_config, init_electron=InitElectron.fc, logging_output=["r_square", "e_occupations"])
+    ct = ChargeTransport(mol_list, evolve_config=evolve_config, compress_config=compress_config, init_electron=InitElectron.fc)
     ct.dump_dir = "./"
     ct.job_name = 'fmo'
     ct.stop_at_edge = False

--- a/renormalizer/mps/mpdm.py
+++ b/renormalizer/mps/mpdm.py
@@ -169,16 +169,7 @@ class MpDm(MpDmBase):
             assert False
 
     def calc_reduced_density_matrix(self) -> np.ndarray:
-        if self.mol_list.scheme < 4:
-            return self._calc_reduced_density_matrix(self, self.conj_trans())
-        elif self.mol_list.scheme == 4:
-            # be careful this method should be read-only
-            copy = self.copy().canonicalise()
-            copy.canonicalise(self.mol_list.e_idx())
-            e_mo = copy[self.mol_list.e_idx()]
-            return tensordot(e_mo, e_mo.conj(), axes=((0, 2 ,3), (0, 2, 3))).asnumpy()[1:, 1:]
-        else:
-            assert False
+        return self._calc_reduced_density_matrix(self, self.conj_trans())
 
     def evolve_exact(self, h_mpo, evolve_dt, space):
         MPOprop, ham, Etot = self.hybrid_exact_propagator(


### PR DESCRIPTION
Now calculating reduced density matrix in scheme4 does not require canonicalization, which is time-consuming.
Also removed the `logging_output` option for `ChargeTransport` because usually it's not necessary to set.