### PR TITLE
Calculate von Neumann entropy for each bond

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,5 @@ example/.ipynb_checkpoints/
 
 doc/html
 doc/doctrees
+doc/build
 

--- a/example/std.yaml
+++ b/example/std.yaml
@@ -14,8 +14,10 @@ ph modes: [[[6.128e-3, a.u.], [16.274571056529368, a.u.]]]
 # temperature
 temperature: [298, K]
 
+# output time interval
+evolve dt: 100
 # total time of evolution in au
-evolve tim: 30000
+evolve time: 30000
 
 # output parameters
 output dir: ./

--- a/example/transport.py
+++ b/example/transport.py
@@ -26,8 +26,8 @@ if __name__ == "__main__":
         os.path.join(param["output dir"], param["fname"] + ".log"), "w"
     )
     mol_list, temperature = load_from_dict(param, 3, False)
-    compress_config = CompressConfig(threshold=1e-4)
-    evolve_config = EvolveConfig(adaptive=True, guess_dt=2)
+    compress_config = CompressConfig(max_bonddim=16)
+    evolve_config = EvolveConfig(EvolveMethod.tdvp_ps, adaptive=True, guess_dt=2)
     ct = ChargeTransport(
         mol_list,
         temperature=temperature,

--- a/renormalizer/mps/mp.py
+++ b/renormalizer/mps/mp.py
@@ -430,7 +430,7 @@ class MatrixProduct:
             # return singular value list
             return self, s_list
 
-    def canonicalise(self, stop_idx: int=None):
+    def canonicalise(self, stop_idx: int=None, normalize=False):
         # stop_idx: mix canonical site at `stop_idx`
         for idx in self.iter_idx_list(full=False, stop_idx=stop_idx):
             mt: Matrix = self[idx]
@@ -450,6 +450,9 @@ class MatrixProduct:
                 system=system,
                 full_matrices=False,
             )
+            if normalize:
+                # roughly normalize. Used when the each site of the mps is scaled such as in exact thermal prop
+                v /= np.linalg.norm(v[:, 0])
             self._update_ms(
                 idx, Matrix(u), Matrix(v.T), sigma=None, qnlset=qnlset, qnrset=qnrset
             )

--- a/renormalizer/mps/mp.py
+++ b/renormalizer/mps/mp.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 # Author: Jiajun Ren <jiajunren0522@gmail.com>
-from __future__ import absolute_import, division
 
-import inspect
 import logging
-import traceback
 from typing import List, Union
 
 import numpy as np
@@ -309,8 +306,9 @@ class MatrixProduct:
         assert self.site_num == other.site_num
         assert self.qnidx == other.qnidx
 
-        # sometimes `other` is complex and `self` is real
-        new_mps = other.metacopy()
+        new_mps = self.metacopy()
+        if other.dtype == backend.complex_dtype:
+            new_mps.dtype = backend.complex_dtype
         if self.is_complex:
             new_mps.to_complex(inplace=True)
         new_mps.compress_config.update(self.compress_config)
@@ -358,9 +356,9 @@ class MatrixProduct:
         else:
             assert False
 
-        new_mps.move_qnidx(self.qnidx)
-        new_mps.to_right = self.to_right
-        new_mps.qn = [qn1 + qn2 for qn1, qn2 in zip(self.qn, new_mps.qn)]
+        new_mps.move_qnidx(other.qnidx)
+        new_mps.to_right = other.to_right
+        new_mps.qn = [qn1 + qn2 for qn1, qn2 in zip(self.qn, other.qn)]
         new_mps.qn[0] = [0]
         new_mps.qn[-1] = [0]
         if self.compress_add:
@@ -368,7 +366,7 @@ class MatrixProduct:
             new_mps.compress()
         return new_mps
 
-    def compress(self, temp_m_trunc=None):
+    def compress(self, temp_m_trunc=None, ret_s=False):
         """
         inp: canonicalise MPS (or MPO)
 
@@ -394,6 +392,7 @@ class MatrixProduct:
                 assert self.check_right_canonical()
         system = "L" if self.to_right else "R"
 
+        s_list = []
         for idx in self.iter_idx_list(full=False):
             mt: Matrix = self[idx]
             if self.to_right:
@@ -410,6 +409,7 @@ class MatrixProduct:
                 full_matrices=False,
             )
             vt = v.T
+            s_list.append(sigma)
             if temp_m_trunc is None:
                 m_trunc = self.compress_config.compute_m_trunc(
                     sigma, idx, self.to_right
@@ -423,7 +423,12 @@ class MatrixProduct:
         self._switch_direction()
         compress_ratio = sz_before / self.total_bytes
         logger.debug(f"size before/after compress: {sizeof_fmt(sz_before)}/{sizeof_fmt(self.total_bytes)}, ratio: {compress_ratio}")
-        return self
+        if not ret_s:
+            # usual exit
+            return self
+        else:
+            # return singular value list
+            return self, s_list
 
     def canonicalise(self, stop_idx: int=None):
         # stop_idx: mix canonical site at `stop_idx`
@@ -496,28 +501,10 @@ class MatrixProduct:
         # regards 1+0j as complex. The former is the desired behavior
         if np.iscomplex(val):
             new_mp.to_complex(inplace=True)
-            # no need to care about negative because no `abs` will be done
-            negative = False
         else:
             val = val.real
-            negative = val < 0
-            val = abs(val)
-        # Note matrices are read-only
-        # there are two ways to do the scaling
-        if np.abs(np.log(np.abs(val))) < 0.01:
-            # Thr first way. The operation performs very quickly,
-            # but leads to high float point error when val is very large or small
-            # val = 2 is considered as very large because the normalization can
-            # be done successively
-            assert new_mp[self.qnidx].array.any()
-            new_mp[self.qnidx] = new_mp[self.qnidx] * val
-        else:
-            # The second way. High time complexity but numerically more feasible.
-            root_val = val ** (1 / len(self))
-            for idx, mt in enumerate(self):
-                new_mp[idx] = mt * root_val
-        if negative:
-            new_mp[0] *= -1
+        assert new_mp[self.qnidx].array.any()
+        new_mp[self.qnidx] = new_mp[self.qnidx] * val
         return new_mp
 
     def to_complex(self, inplace=False):

--- a/renormalizer/mps/mpo.py
+++ b/renormalizer/mps/mpo.py
@@ -27,10 +27,6 @@ logger = logging.getLogger(__name__)
 # todo: refactor init
 # the code is hard to understand...... need some closer look
 
-# todo: refactor scheme4, add QN and the 0 electron state!
-# the problem of the current scheme4 is that there are states (0 electron state) that the
-# scheme can not represent
-
 def base_convert(n, base):
     """
     convert 10 base number to any base number

--- a/renormalizer/mps/mps.py
+++ b/renormalizer/mps/mps.py
@@ -496,7 +496,9 @@ class Mps(MatrixProduct):
                 else:
                     assert False
                 ex_state.compress_config = self.compress_config
-                lastone = ex_state + self
+                ex_state.move_qnidx(self.qnidx)
+                ex_state.to_right = self.to_right
+                lastone = self + ex_state
 
             else:
                 lastone = self
@@ -819,7 +821,8 @@ class Mps(MatrixProduct):
             logger.debug(f"ww.min={sw_min_list.min()}, Switch to tdvp_mu_vmf")
             mps.evolve_config.method =  EvolveMethod.tdvp_mu_vmf
 
-        return mps
+        # The caller do not want to deal with an MPS that is not canonicalised
+        return mps.canonicalise()
 
     @adaptive_tdvp
     def _evolve_dmrg_tdvp_mu_cmf(self, mpo, evolve_dt) -> "Mps":
@@ -1120,7 +1123,7 @@ class Mps(MatrixProduct):
 
     @property
     def digest(self):
-        if 10 < self.site_num:
+        if 10 < self.site_num or self.is_mpdm:
             return None
         prod = np.eye(1).reshape(1, 1, 1)
         for ms in self:
@@ -1310,6 +1313,24 @@ class Mps(MatrixProduct):
         mp1 = [mt.reshape(mt.shape[0], mt.shape[1], 1, mt.shape[2]) for mt in self]
         mp2 = [mt.reshape(mt.shape[0], 1, mt.shape[1], mt.shape[2]).conj() for mt in self]
         return self._calc_reduced_density_matrix(mp1, mp2)
+
+    def calc_vn_entropy(self) -> np.ndarray:
+        r"""
+        Calculate von Neumann entropy at each bond according to :math:`S = -\textrm{Tr}(\rho \ln \rho)`
+        where :math:`\rho` is the density matrix.
+
+        Returns:
+            a NumPy array containing the entropy values.
+        """
+        _, s_list = self.compress(temp_m_trunc=np.inf, ret_s=True)
+        entropy_list = []
+        for sigma in s_list:
+            rho = sigma ** 2
+            normed_rho = rho / rho.sum()
+            truncate_rho = normed_rho[0 < normed_rho]
+            entropy = - (truncate_rho * np.log(truncate_rho)).sum()
+            entropy_list.append(entropy)
+        return np.array(entropy_list)
 
     def dump(self, fname):
         data_dict = dict()

--- a/renormalizer/mps/tests/test_mpdm.py
+++ b/renormalizer/mps/tests/test_mpdm.py
@@ -78,7 +78,7 @@ def test_thermal_prop(mol_list, etot_std, occ_std, adaptive, evolve_method, rtol
         nsteps = 20
         evolve_config.ivp_rtol=1e-3
         evolve_config.ivp_atol=1e-6
-        init_mps.compress_config.bond_dim_max_value=16
+        init_mps.compress_config.bond_dim_max_value = 16
 
     dbeta = evolve_time/nsteps
 

--- a/renormalizer/mps/thermalprop.py
+++ b/renormalizer/mps/thermalprop.py
@@ -85,10 +85,8 @@ class ThermalProp(TdMpsJob):
         unitary_propagation(new_mpdm.tdh_wfns, HAM, Etot, evolve_dt)
         # partition function can't be obtained. It's not practical anyway.
         # The function is too large to be fit into float64 even float128
+        new_mpdm.canonicalise(normalize=True)
         new_mpdm.normalize(1.0)
-        # the mpdm may not be canonicalised due to distributed scaling. It's not wise to do
-        # so currently because scheme4 might have empty matrices
-        # new_mpdm.canonicalise()
         return new_mpdm
 
     def evolve_prop(self, old_mpdm, evolve_dt):

--- a/renormalizer/utils/constant.py
+++ b/renormalizer/utils/constant.py
@@ -33,4 +33,6 @@ def nm2au(l):
 def au2nm(e):
     return 1.0e7 / (e / cm2au)
 
+# 1 cm^2/V s = mobility2au a.u.
+# mobility2au = 23.505175500558234
 mobility2au = au2ev * c["atomic unit of time"][0] / (c["atomic unit of length"][0] * 100) ** 2


### PR DESCRIPTION
Add a method for `Mps` to calculate von Neumann entropy for each bond.
Now `ChargeTransport` and `ThermalProp` will record and dump this information for further analysis.
The original `vn_entropy` in `ChargeTransport` which is based on the density matrix of the electron DOFs is renamed to `eph_vn_entropy` to distinguish from the new one.