### PR TITLE
optimize autocorr calculation

### DIFF
--- a/renormalizer/mps/matrix.py
+++ b/renormalizer/mps/matrix.py
@@ -129,14 +129,10 @@ class Matrix:
         s = xp.dot(tensm, tensm.T.conj())
         return allclose(s, xp.eye(s.shape[0]), rtol=rtol, atol=atol)
 
-    def to_complex(self, inplace=False):
+    def to_complex(self):
         # `xp.array` always creates new array, so to_complex means copy, which is
         # in accordance with NumPy
-        if inplace:
-            self.array = xp.array(self.array, dtype=backend.complex_dtype)
-            return self
-        else:
-            return xp.array(self.array, dtype=backend.complex_dtype)
+        return xp.array(self.array, dtype=backend.complex_dtype)
 
     def copy(self):
         new = self.__class__(self.array.copy(), self.array.dtype)
@@ -204,6 +200,9 @@ class Matrix:
 
     def __float__(self):
         return self.array.__float__()
+
+    def __complex__(self):
+        return self.array.__complex__()
 
 
 def zeros(shape, dtype=None):

--- a/renormalizer/mps/mp.py
+++ b/renormalizer/mps/mp.py
@@ -530,7 +530,7 @@ class MatrixProduct:
             if mt is None:
                 # dummy mt after metacopy. Bad idea. Remove the dummy thing when feasible
                 continue
-            new_mp[i] = mt.to_complex(inplace)
+            new_mp[i] = mt.to_complex()
         return new_mp
 
     def distance(self, other) -> float:

--- a/renormalizer/transport/autocorr.py
+++ b/renormalizer/transport/autocorr.py
@@ -95,7 +95,6 @@ class TransportAutoCorr(TdMpsJob):
     def evolve_single_step(self, evolve_dt):
         prev_bra_mpdm, prev_ket_mpdm = self.latest_mps
         latest_ket_mpdm = prev_ket_mpdm.evolve(self.h_mpo, evolve_dt)
-        prev_bra_mpdm.evolve_config.guess_dt = -prev_ket_mpdm.evolve_config.guess_dt
         latest_bra_mpdm = prev_bra_mpdm.evolve(self.h_mpo, evolve_dt)
         return BraKetPair(latest_bra_mpdm, latest_ket_mpdm, self.j_oper)
 

--- a/renormalizer/transport/tests/test_autocorr.py
+++ b/renormalizer/transport/tests/test_autocorr.py
@@ -15,10 +15,10 @@ def test_autocorr():
     mol_list = MolList([mol] * 5, Quantity(1), 3)
     temperature = Quantity(50000, 'K')
     compress_config = CompressConfig(CompressCriteria.fixed, max_bonddim=24)
-    evolve_config = EvolveConfig(EvolveMethod.tdvp_ps)
-    ievolve_config = evolve_config.copy()
+    evolve_config = EvolveConfig(EvolveMethod.tdvp_ps, adaptive=True, guess_dt=0.5, adaptive_rtol=1e-3)
+    ievolve_config = EvolveConfig(EvolveMethod.tdvp_ps, adaptive=True, guess_dt=-0.1j)
     ac = TransportAutoCorr(mol_list, temperature, compress_config=compress_config, ievolve_config=ievolve_config, evolve_config=evolve_config)
-    ac.evolve(0.4, 25)
+    ac.evolve(nsteps=5, evolve_time=5)
     corr_real = ac.auto_corr.real
     exact_real = get_exact_autocorr(mol_list, temperature, ac.evolve_times_array).real
     atol = 1e-2


### PR DESCRIPTION
When evaluating the correlation avoid calculating `self.mpo @ self.ket_mps` directly which is time and memory consuming.

The `Matrix` class is modified so that in place modification is not permitted. Inplace modification will not affect the logic of `interned` and the data type in `Mpo` could become unexpected.