### PR TITLE
cmf updates and polaron structure

### DIFF
--- a/renormalizer/lib/krylov/krylov.py
+++ b/renormalizer/lib/krylov/krylov.py
@@ -23,7 +23,7 @@ def _expm_krylov(alpha, beta, V, v_norm, dt):
 
     xp_w_hess = xp.array(w_hess)
     xp_u_hess = xp.array(u_hess)
-
+    
     return V @ xp_u_hess @ (v_norm * xp.exp(dt*xp_w_hess) * xp_u_hess[0])
 
 
@@ -62,16 +62,15 @@ def expm_krylov(Afunc, dt, vstart: xp.ndarray, block_size=50):
         beta[j] = xp.linalg.norm(w)
         if beta[j] < 100*len(vstart)*np.finfo(float).eps:
             logger.warning(f'beta[{j}] ~= 0 encountered during Lanczos iteration.')
-            return _expm_krylov(alpha[:j+1], beta[:j], V[:j+1, :].T, nrmv, dt), j
+            return _expm_krylov(alpha[:j+1], beta[:j], V[:j+1, :].T, nrmv, dt), j+1
 
         if 3 < j and j % 2 == 0:
             new_res = _expm_krylov(alpha[:j+1], beta[:j], V[:j+1].T, nrmv, dt)
             if res is not None and xp.allclose(res, new_res):
-                return new_res, j
+                return new_res, j+1
             else:
                 res = new_res
         V[j + 1] = w / beta[j]
-    return _expm_krylov(alpha, beta, V.T, nrmv, dt), j
-
+    return _expm_krylov(alpha[:j+1], beta[:j], V[:j+1].T, nrmv, dt), j+1
 
 

--- a/renormalizer/mps/mp.py
+++ b/renormalizer/mps/mp.py
@@ -545,7 +545,7 @@ class MatrixProduct:
             assert dis_square/l1.real < 1e-8
             res = 0.
         else:
-            res = np.sqrt(dis_square)
+            res = np.sqrt(dis_square).item()
         
         return res
 

--- a/renormalizer/mps/mpo.py
+++ b/renormalizer/mps/mpo.py
@@ -559,40 +559,49 @@ class Mpo(MatrixProduct):
         return mpo
 
     @classmethod
-    def e_intersite(cls, mol_list: MolList, opera: dict, scale:
+    def intersite(cls, mol_list: MolList, e_opera: dict, ph_opera: dict, scale:
             Quantity=Quantity(1.)):
-        ''' construct the inter electronic site MPO
+        ''' construct the inter site MPO
         Parameters:
             mol_list : MolList
                 the molecular information
-            opera: 
-                the operators such as {1:"a", 3:r"a^\dagger"}
+            e_opera: 
+                the electronic operators. {imol: operator}, such as {1:"a", 3:r"a^\dagger"}
+            ph_opera:
+                the vibrational operators. {(imol,iph): operator}, such as {(0,5):"b"}
             scale: Quantity
                 scalar to scale the mpo
+
+        Note:
+            the operator index starts from 0,1,2...
         '''
 
         if mol_list.scheme == 4:
             raise NotImplementedError
 
-        for i in opera.keys():
+        for i in e_opera.keys():
             assert i in range(mol_list.mol_num)
+        for j in ph_opera.keys():
+            assert j[0] in range(mol_list.mol_num)
+            assert j[1] in range(mol_list[j[0]].n_dmrg_phs)
         
         mpo = cls()
         mpo.mol_list = mol_list
         mpo.qn = [[0]]
 
         impo = 0
+        eop = construct_e_op_dict()
+
         for imol in range(mol_list.mol_num):
-            eop = construct_e_op_dict()
             mo = np.zeros([1, 2, 2, 1])
 
-            if imol in opera.keys():
-                mo[0, :, :, 0] = eop[opera[imol]]
-                if opera[imol] == r"a^\dagger":
+            if imol in e_opera.keys():
+                mo[0, :, :, 0] = eop[e_opera[imol]]
+                if e_opera[imol] == r"a^\dagger":
                     mpo.qn.append([mpo.qn[-1][0]+1])
-                elif opera[imol] == "a":
+                elif e_opera[imol] == "a":
                     mpo.qn.append([mpo.qn[-1][0]-1])
-                elif opera[imol] == r"a^\dagger a":
+                elif e_opera[imol] == r"a^\dagger a":
                     mpo.qn.append(mpo.qn[-1])
                 else:
                     assert False
@@ -602,17 +611,24 @@ class Mpo(MatrixProduct):
             
             mpo.append(mo)
             impo += 1
+            
+            assert mol_list[imol].no_qboson
 
-            for ph in mol_list[imol].dmrg_phs:
-                for iboson in range(ph.nqboson):
-                    pbond = mol_list.pbond_list[impo]
-                    mo = np.zeros([1, pbond, pbond, 1])
-                    for ibra in range(pbond):
-                        mo[0, ibra, ibra, 0] = 1.0
-                    mpo.qn.append(mpo.qn[-1])
+            for iph in range(mol_list[imol].n_dmrg_phs):
+                pbond = mol_list.pbond_list[impo]
+                mo = np.zeros([1, pbond, pbond, 1])
+                phop = construct_ph_op_dict(pbond)
+                
+                if (imol, iph) in ph_opera.keys():
+                    mo[0, :, :, 0] = phop[ph_opera[(imol,iph)]]
+                else:
+                    mo[0, :, :, 0] = phop["Iden"]
 
-                    mpo.append(mo)
-                    impo += 1
+                mpo.qn.append(mpo.qn[-1])
+
+                mpo.append(mo)
+                impo += 1
+
         mpo.qnidx = len(mpo) - 1
         mpo.to_right = False
         

--- a/renormalizer/mps/mps.py
+++ b/renormalizer/mps/mps.py
@@ -387,8 +387,10 @@ class Mps(MatrixProduct):
         # return self_conj.dot(mpo.apply(self), with_hartree=False).real
 
     def expectations(self, mpos, opt=True) -> np.ndarray:
-        if not opt:
+        if (not opt) or (len(mpos) < 3):
             return np.array([self.expectation(mpo) for mpo in mpos])
+
+        # todo: figure out when the `else` part can work.
         else:
             # only supports local operator now
             # id can be used as efficient hash because of `Matrix` implementation

--- a/renormalizer/mps/svd_qn.py
+++ b/renormalizer/mps/svd_qn.py
@@ -219,13 +219,13 @@ def blockrecover(indices, U, dim):
 def cvec2cmat(cshape, c, qnmat, nexciton, nroots=1):
     # recover good quantum number vector c to matrix format
     if nroots == 1:
-        cstruct = np.zeros(cshape, dtype=c.dtype)
-        np.place(cstruct, qnmat == nexciton, c)
+        cstruct = xp.zeros(cshape, dtype=c.dtype)
+        xp.place(cstruct, qnmat == nexciton, c)
     else:
         cstruct = []
         for ic in c:
-            icstruct = np.zeros(cshape, dtype=ic.dtype)
-            np.place(icstruct, qnmat == nexciton, ic)
+            icstruct = xp.zeros(cshape, dtype=ic.dtype)
+            xp.place(icstruct, qnmat == nexciton, ic)
             cstruct.append(icstruct)
 
     return cstruct

--- a/renormalizer/mps/tests/test_evolve.py
+++ b/renormalizer/mps/tests/test_evolve.py
@@ -80,7 +80,7 @@ def test_tdvp_cmf(init_state):
 def test_tdvp_ps(init_state):
     mps = init_state.copy()
     mps.evolve_config  = EvolveConfig(EvolveMethod.tdvp_ps)
-    check_result(mps, mpo, 0.5, 5)
+    check_result(mps, mpo, 0.4, 5)
 
 
 # used for debugging

--- a/renormalizer/mps/tests/test_mpo.py
+++ b/renormalizer/mps/tests/test_mpo.py
@@ -75,19 +75,19 @@ def test_scheme4():
     e3 = mps3.expectation(mpo3)
     assert pytest.approx(e4) == e3
 
-def test_e_intersite():
-    mpo1 = Mpo.e_intersite(mol_list, {0:r"a^\dagger"}, Quantity(1.0))
+def test_intersite():
+    mpo1 = Mpo.intersite(mol_list, {0:r"a^\dagger"}, {}, Quantity(1.0))
     mpo2 = Mpo.onsite(mol_list, r"a^\dagger", mol_idx_set=[0])
     assert mpo1.distance(mpo2) == pytest.approx(0, abs=1e-5)
     
-    mpo3 = Mpo.e_intersite(mol_list, {2:r"a^\dagger a"}, Quantity(1.0))
+    mpo3 = Mpo.intersite(mol_list, {2:r"a^\dagger a"}, {}, Quantity(1.0))
     mpo4 = Mpo.onsite(mol_list, r"a^\dagger a", mol_idx_set=[2])
     assert mpo3.distance(mpo4) == pytest.approx(0, abs=1e-5)
     
-    mpo5 = Mpo.e_intersite(mol_list, {2:r"a^\dagger a"}, Quantity(0.5))
+    mpo5 = Mpo.intersite(mol_list, {2:r"a^\dagger a"}, {}, Quantity(0.5))
     assert mpo5.add(mpo5).distance(mpo4) == pytest.approx(0, abs=1e-5)
     
-    mpo6 = Mpo.e_intersite(mol_list, {0:r"a^\dagger",2:"a"}, Quantity(1.0))
+    mpo6 = Mpo.intersite(mol_list, {0:r"a^\dagger",2:"a"}, {}, Quantity(1.0))
     mpo7 = Mpo.onsite(mol_list, "a", mol_idx_set=[2])
     assert mpo2.apply(mpo7).distance(mpo6) == pytest.approx(0, abs=1e-5)
     
@@ -96,13 +96,17 @@ def test_e_intersite():
     mol_list1 = mol_list.switch_scheme(2)
     mol_list1.scheme=3
     mpo9 = Mpo(mol_list1)
-    mpo10 = Mpo.e_intersite(mol_list1, {0:r"a^\dagger",2:"a"},
+    mpo10 = Mpo.intersite(mol_list1, {0:r"a^\dagger",2:"a"}, {},
             Quantity(mol_list1.j_matrix[0,2]))
-    mpo11 = Mpo.e_intersite(mol_list1, {2:r"a^\dagger",0:"a"},
+    mpo11 = Mpo.intersite(mol_list1, {2:r"a^\dagger",0:"a"}, {},
             Quantity(mol_list1.j_matrix[0,2]))
     
     assert mpo8.distance(mpo9.add(mpo10).add(mpo11)) == pytest.approx(0, abs=1e-6)
     assert mpo8.distance(mpo9.add(mpo10).add(mpo10.conj_trans())) == pytest.approx(0, abs=1e-6)
+    
+    ph_mpo1 = Mpo.ph_onsite(mol_list, "b", 1, 1)
+    ph_mpo2 = Mpo.intersite(mol_list, {}, {(1,1):"b"})
+    assert ph_mpo1.distance(ph_mpo2) == pytest.approx(0, abs=1e-6)
 
 
 def test_phonon_onsite():

--- a/renormalizer/transport/autocorr.py
+++ b/renormalizer/transport/autocorr.py
@@ -52,7 +52,7 @@ class TransportAutoCorr(TdMpsJob):
         logger.debug("constructing flux operator")
         j_list = []
         for i in range(len(self.mol_list) - 1):
-            j1 = Mpo.e_intersite(self.mol_list, {i:r"a", i+1:r"a^\dagger"}, Quantity(self.mol_list.j_matrix[i, i + 1]))
+            j1 = Mpo.intersite(self.mol_list, {i:r"a", i+1:r"a^\dagger"}, {}, Quantity(self.mol_list.j_matrix[i, i + 1]))
             j1.compress_config.threshold = 1e-5
             j2 = j1.conj_trans().scale(-1)
             j_list.extend([j1, j2])

--- a/renormalizer/utils/configs.py
+++ b/renormalizer/utils/configs.py
@@ -251,6 +251,7 @@ class EvolveConfig:
         self.adaptive_rtol = adaptive_rtol
 
         self.tdvp_cmf_midpoint = True
+        self.tdvp_cmf_c_trapz = False
         # regularization parameter in tdvp_mu or tdvp_std method
         self.reg_epsilon: float = reg_epsilon
         # scipy.ivp rtol and atol

--- a/renormalizer/utils/constant.py
+++ b/renormalizer/utils/constant.py
@@ -10,20 +10,27 @@ from scipy.constants import physical_constants as c
 # 1 a.u. = au2ev eV
 au2ev = c["Hartree energy in eV"][0]
 
+
 # 1 cm^-1 = cm2au a.u.
 cm2au = (
     1.0e2
     * c["inverse meter-hertz relationship"][0]
     / c["hartree-hertz relationship"][0]
 )
+au2cm = 1./ cm2au
 
 # 1 cm^-1 = cm2ev eV
 cm2ev = cm2au * au2ev
+ev2cm = 1./cm2ev
 
 # 1 fs = fs2au a.u
 fs2au = 1.0e-15 / c["atomic unit of time"][0]
 K2au = c["kelvin-hartree relationship"][0]
 au2K = c["hartree-kelvin relationship"][0]
+
+# atomic mass unit
+amu2au = c["atomic mass constant"][0] / c["atomic unit of mass"][0]
+angstrom2au = 1e-10 / c["atomic unit of length"][0] 
 
 # nm to au
 def nm2au(l):


### PR DESCRIPTION
1. in cmf evolution scheme: add the trapz scheme for C tensor (the last site) to be consistent with the original cmf paper. (preliminary test indicates no significant difference with the original pure midpoint implementation) The control flag in `Evolve_Config` is `tdvp_cmf_c_trapz = False` .

2. fix bug in `krylov.py` for case with small physical bond dimension.

3. in class `Mpo`, a new class method `intersite` is written to replace the former `e_intersite` to include the e-ph operator and pure phonon operator.