### PR TITLE
fix several bugs and add doc

### DIFF
--- a/renormalizer/mps/mp.py
+++ b/renormalizer/mps/mp.py
@@ -95,7 +95,7 @@ class MatrixProduct:
 
     @property
     def bond_dims_mean(self) -> int:
-        return int(np.mean(self.bond_dims))
+        return int(round(np.mean(self.bond_dims)))
 
     @property
     def ephtable(self):
@@ -201,7 +201,7 @@ class MatrixProduct:
             self.move_qnidx(0)
             self.to_right = True
             self.canonicalise()
-    
+
     def ensure_right_canon(self, rtol=1e-5, atol=1e-8):
         if not self.check_right_canonical(rtol, atol):
             self.move_qnidx(self.site_num - 1)
@@ -471,7 +471,7 @@ class MatrixProduct:
 
     def dot(self, other: "MatrixProduct") -> complex:
         """
-        dot product of two mps / mpo 
+        dot product of two mps / mpo
         """
 
         assert len(self) == len(other)
@@ -523,19 +523,19 @@ class MatrixProduct:
         return new_mp
 
     def distance(self, other) -> float:
-        l1 = self.conj().dot(self) 
+        l1 = self.conj().dot(self)
         l2 = other.conj().dot(other)
         l1dotl2 = self.conj().dot(other)
         dis_square = (l1 + l2
             - l1dotl2
             - l1dotl2.conjugate()).real
-        
+
         if dis_square < 0:
             assert dis_square/l1.real < 1e-8
             res = 0.
         else:
             res = np.sqrt(dis_square).item()
-        
+
         return float(res)
 
     def copy(self):

--- a/renormalizer/mps/mps.py
+++ b/renormalizer/mps/mps.py
@@ -383,9 +383,12 @@ class Mps(MatrixProduct):
     def expectations(self, mpos, opt=True) -> np.ndarray:
         if (not opt) or (len(mpos) < 3):
             return np.array([self.expectation(mpo) for mpo in mpos])
-        # todo: figure out when the `else` part can work.
         else:
-            # only supports local operator now
+            # only supports `mpos` with bond dimension 1, and all `mpos`
+            # must be only one site different from another standard MPO. For example
+            # [XBCDE, AXCDE, ABXDE, ABCXE, ABCDX]
+            # and the order does not matter
+
             # id can be used as efficient hash because of `Matrix` implementation
             mpo_ids = np.array([[id(m) for m in mpo] for mpo in mpos])
             common_mpo_ids = mpo_ids[0].copy()
@@ -497,7 +500,8 @@ class Mps(MatrixProduct):
             # in case of localized `self`
             if not self.use_dummy_qn:
                 if self.is_mps:
-                    ex_state: MatrixProduct = self.random(self.mol_list, 1, 10)
+                    ex_state: MatrixProduct = self.gs(self.mol_list, False)
+                    ex_state = Mpo.onsite(self.mol_list, r"a^\dagger") @ ex_state
                 elif self.is_mpdm:
                     ex_state: MatrixProduct = self.max_entangled_ex(self.mol_list)
                 else:
@@ -528,7 +532,7 @@ class Mps(MatrixProduct):
                     lastone = lastone.canonicalise().compress(
                         m_target // hint_mpo.bond_dims_mean
                     )
-                lastone = hint_mpo @ lastone
+                lastone = (hint_mpo @ lastone)._dmrg_normalize()
         logger.debug(f"expander bond dimension: {expander.bond_dims}")
         self.compress_config.bond_dim_max_value += self.bond_dims_mean
         return (self + expander.scale(coef, inplace=True)).canonicalise().canonicalise().canonical_normalize()


### PR DESCRIPTION
Bug fixes:
- When calculating the mean bond dimension for a `MatrixProduct` direct truncation to `int` would discard the decimal part. Rounding the closest integer should be performed firstly.
- When expanding bond dimension
    - For `Mps` `self.random(self.mol_list, 1, 10)` is not a good excited state because the charge could be localized.
    - Each `lastone` should be normalized. Otherwise, each time applying `hint_mpo` would produce a coefficient that affects the quality of the returned `Mps` `(self + expander.scale(coef, inplace=True))`

Add doc for `expectations` as discussed in #74 