### PR TITLE
add scheme 4 support for transport autocorr

### DIFF
--- a/renormalizer/model/mlist.py
+++ b/renormalizer/model/mlist.py
@@ -15,7 +15,7 @@ from renormalizer.utils.utils import cast_float
 class MolList:
 
     def __init__(self, mol_list: List[Mol], j_matrix: Union[Quantity, np.ndarray, None], scheme: int = 2, periodic: bool = False):
-        self.period = periodic
+        self.periodic = periodic
         self.mol_list: List[Mol] = mol_list
 
         # construct the electronic coupling matrix
@@ -85,7 +85,7 @@ class MolList:
         return True
 
     def switch_scheme(self, scheme):
-        return self.__class__(self.mol_list.copy(), self.j_matrix.copy(), scheme, self.period)
+        return self.__class__(self.mol_list.copy(), self.j_matrix.copy(), scheme, self.periodic)
 
     def copy(self):
         return self.switch_scheme(self.scheme)

--- a/renormalizer/model/mlist.py
+++ b/renormalizer/model/mlist.py
@@ -14,12 +14,13 @@ from renormalizer.utils.utils import cast_float
 
 class MolList:
 
-    def __init__(self, mol_list: List[Mol], j_matrix: Union[Quantity, np.ndarray, None], scheme: int=2, sbm=False, period=False):
+    def __init__(self, mol_list: List[Mol], j_matrix: Union[Quantity, np.ndarray, None], scheme: int=2, period=False):
         self.period = period
         self.mol_list: List[Mol] = mol_list
 
         # construct the electronic coupling matrix
-        if sbm or j_matrix is None:
+        if j_matrix is None:
+            # spin-boson model
             assert len(self.mol_list) == 1
             j_matrix = Quantity(0)
 
@@ -82,7 +83,10 @@ class MolList:
         return True
 
     def switch_scheme(self, scheme):
-        return self.__class__(self.mol_list, self.j_matrix, scheme)
+        return self.__class__(self.mol_list.copy(), self.j_matrix.copy(), scheme, self.period)
+
+    def copy(self):
+        return self.switch_scheme(self.scheme)
 
     def e_idx(self, idx=0):
         return self._e_idx[idx]

--- a/renormalizer/mps/mp.py
+++ b/renormalizer/mps/mp.py
@@ -132,12 +132,12 @@ class MatrixProduct:
 
     def build_empty_qn(self):
         self.qntot = 0
-        # retain qnidx to indicate left or right canonicalise
+        # set qnidx to the right to be consistent with most MPS/MPO setups
         if self.qnidx is None:
-            self.qnidx = 0
+            self.qnidx = len(self) - 1
         self.qn = [[0] * dim for dim in self.bond_dims]
         if self.to_right is None:
-            self.to_right = True
+            self.to_right = False
 
     def build_none_qn(self):
         self.qntot = None
@@ -602,6 +602,7 @@ class MatrixProduct:
         return iter(self._mp)
 
     def __len__(self):
+        # The same semantic with `list`
         return len(self._mp)
 
     def __mul__(self, other):

--- a/renormalizer/mps/mpo.py
+++ b/renormalizer/mps/mpo.py
@@ -1297,7 +1297,7 @@ class Mpo(MatrixProduct):
 
                         self.append(mo)
                         impo += 1
-        if mol_list.period is True:
+        if mol_list.periodic is True:
             if scheme == 2 or scheme == 4:
                 assert not np.allclose(mol_list.j_matrix[0, -1], 0)
                 assert not np.allclose(mol_list.j_matrix[-1, 0], 0)

--- a/renormalizer/mps/mpo.py
+++ b/renormalizer/mps/mpo.py
@@ -596,16 +596,21 @@ class Mpo(MatrixProduct):
                     it = iter(e_opera.items())
                     if len(e_opera) == 0:
                         mo = np.diag(np.ones(pdim))
+                        mpo.qn.append(mpo.qn[-1])
                     elif len(e_opera) == 1:
                         idx, op = next(it)
                         if op == r"a^\dagger a":
                             mo[idx+1, idx+1] = 1
+                            qn = 0
                         elif op == r"a^\dagger":
                             mo[idx+1, 0] = 1
+                            qn = 1
                         elif op == r"a":
                             mo[0, idx+1] = 1
+                            qn = -1
                         else:
                             assert False
+                        mpo.qn.append([qn])
                     elif len(e_opera) == 2:
                         idx1, op1 = next(it)
                         idx2, op2 = next(it)
@@ -615,9 +620,9 @@ class Mpo(MatrixProduct):
                             mo[idx2+1, idx1+1] = 1
                         else:
                             mo[idx1+1, idx2+1] = 1
+                        mpo.qn.append(mpo.qn[-1])
                     else:
                         assert False
-                    mpo.qn.append(mpo.qn[-1])
                     mpo.append(mo.reshape(1, pdim, pdim, 1))
                 # else do nothing. Wait for the right time.
             else:

--- a/renormalizer/mps/tests/test_mpo.py
+++ b/renormalizer/mps/tests/test_mpo.py
@@ -37,6 +37,7 @@ def test_offset(scheme):
     evals2, _ = np.linalg.eigh(f2)
     assert np.allclose(evals1 - offset.as_au(), evals2)
 
+
 def test_identity():
     identity = Mpo.identity(mol_list)
     mps = Mps.random(mol_list, nexciton=1, m_max=5)
@@ -75,42 +76,49 @@ def test_scheme4():
     e3 = mps3.expectation(mpo3)
     assert pytest.approx(e4) == e3
 
-def test_intersite():
-    mpo1 = Mpo.intersite(mol_list, {0:r"a^\dagger"}, {}, Quantity(1.0))
-    mpo2 = Mpo.onsite(mol_list, r"a^\dagger", mol_idx_set=[0])
+
+@pytest.mark.parametrize("scheme", (2, 3, 4))
+def test_intersite(scheme):
+
+    local_mlist = mol_list.switch_scheme(scheme)
+
+    mpo1 = Mpo.intersite(local_mlist, {0:r"a^\dagger"}, {}, Quantity(1.0))
+    mpo2 = Mpo.onsite(local_mlist, r"a^\dagger", mol_idx_set=[0])
     assert mpo1.distance(mpo2) == pytest.approx(0, abs=1e-5)
 
-    mpo3 = Mpo.intersite(mol_list, {2:r"a^\dagger a"}, {}, Quantity(1.0))
-    mpo4 = Mpo.onsite(mol_list, r"a^\dagger a", mol_idx_set=[2])
+    mpo3 = Mpo.intersite(local_mlist, {2:r"a^\dagger a"}, {}, Quantity(1.0))
+    mpo4 = Mpo.onsite(local_mlist, r"a^\dagger a", mol_idx_set=[2])
     assert mpo3.distance(mpo4) == pytest.approx(0, abs=1e-5)
 
-    mpo5 = Mpo.intersite(mol_list, {2:r"a^\dagger a"}, {}, Quantity(0.5))
+    mpo5 = Mpo.intersite(local_mlist, {2:r"a^\dagger a"}, {}, Quantity(0.5))
     assert mpo5.add(mpo5).distance(mpo4) == pytest.approx(0, abs=1e-5)
 
-    mpo6 = Mpo.intersite(mol_list, {0:r"a^\dagger",2:"a"}, {}, Quantity(1.0))
-    mpo7 = Mpo.onsite(mol_list, "a", mol_idx_set=[2])
+    mpo6 = Mpo.intersite(local_mlist, {0:r"a^\dagger",2:"a"}, {}, Quantity(1.0))
+    mpo7 = Mpo.onsite(local_mlist, "a", mol_idx_set=[2])
     assert mpo2.apply(mpo7).distance(mpo6) == pytest.approx(0, abs=1e-5)
 
-    mpo8 = Mpo(mol_list)
-    # a dirty hack to switch from scheme 2 to scheme 3
-    mol_list1 = mol_list.switch_scheme(2)
-    mol_list1.scheme=3
-    mpo9 = Mpo(mol_list1)
-    mpo10 = Mpo.intersite(mol_list1, {0:r"a^\dagger",2:"a"}, {},
-            Quantity(mol_list1.j_matrix[0,2]))
-    mpo11 = Mpo.intersite(mol_list1, {2:r"a^\dagger",0:"a"}, {},
-            Quantity(mol_list1.j_matrix[0,2]))
+    # the tests are based on the similarity between scheme 2 and scheme 3
+    # so scheme 3 and scheme 4 will be skipped
+    if scheme == 2:
+        mpo8 = Mpo(local_mlist)
+        # a dirty hack to switch from scheme 2 to scheme 3
+        test_mlist = local_mlist.switch_scheme(2)
+        test_mlist.scheme = 3
+        mpo9 = Mpo(test_mlist)
+        mpo10 = Mpo.intersite(test_mlist, {0:r"a^\dagger",2:"a"}, {},
+                Quantity(local_mlist.j_matrix[0,2]))
+        mpo11 = Mpo.intersite(test_mlist, {2:r"a^\dagger",0:"a"}, {},
+                Quantity(local_mlist.j_matrix[0,2]))
 
-    assert mpo8.distance(mpo9.add(mpo10).add(mpo11)) == pytest.approx(0, abs=1e-6)
-    assert mpo8.distance(mpo9.add(mpo10).add(mpo10.conj_trans())) == pytest.approx(0, abs=1e-6)
+        assert mpo11.conj_trans().distance(mpo10) == pytest.approx(0, abs=1e-6)
+        assert mpo8.distance(mpo9 + mpo10 + mpo11) == pytest.approx(0, abs=1e-6)
 
-    mol_list1.period = True
-    mpo12 = Mpo(mol_list1)
-    assert mpo12.distance(mpo9.add(mpo10).add(mpo11)) == pytest.approx(0, abs=1e-6)
+        test_mlist.period = True
+        mpo12 = Mpo(test_mlist)
+        assert mpo12.distance(mpo9 + mpo10 + mpo11) == pytest.approx(0, abs=1e-6)
 
-
-    ph_mpo1 = Mpo.ph_onsite(mol_list, "b", 1, 1)
-    ph_mpo2 = Mpo.intersite(mol_list, {}, {(1,1):"b"})
+    ph_mpo1 = Mpo.ph_onsite(local_mlist, "b", 1, 1)
+    ph_mpo2 = Mpo.intersite(local_mlist, {}, {(1,1):"b"})
     assert ph_mpo1.distance(ph_mpo2) == pytest.approx(0, abs=1e-6)
 
 

--- a/renormalizer/mps/tests/test_mpo.py
+++ b/renormalizer/mps/tests/test_mpo.py
@@ -113,7 +113,7 @@ def test_intersite(scheme):
         assert mpo11.conj_trans().distance(mpo10) == pytest.approx(0, abs=1e-6)
         assert mpo8.distance(mpo9 + mpo10 + mpo11) == pytest.approx(0, abs=1e-6)
 
-        test_mlist.period = True
+        test_mlist.periodic = True
         mpo12 = Mpo(test_mlist)
         assert mpo12.distance(mpo9 + mpo10 + mpo11) == pytest.approx(0, abs=1e-6)
 

--- a/renormalizer/property/test/test_polaron_structure.py
+++ b/renormalizer/property/test/test_polaron_structure.py
@@ -63,9 +63,9 @@ mol_list = MolList([Mol(Quantity(elocalex), [ph], dipole_abs)] * nmols,
 
 # periodic nearest-neighbour interaction
 mpo = Mpo(mol_list)
-period = Mpo.intersite(mol_list, {0:r"a^\dagger",nmols-1:"a"}, {},
-        Quantity(j_value))
-mpo = mpo.add(period).add(period.conj_trans())
+periodic = Mpo.intersite(mol_list, {0: r"a^\dagger", nmols - 1: "a"}, {},
+                         Quantity(j_value))
+mpo = mpo.add(periodic).add(periodic.conj_trans())
 
 
 @pytest.mark.parametrize("periodic",(True, False))

--- a/renormalizer/transport/tests/test_autocorr.py
+++ b/renormalizer/transport/tests/test_autocorr.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import qutip
+import pytest
 
 from renormalizer.model import Phonon, Mol, MolList
 from renormalizer.transport.autocorr import TransportAutoCorr
@@ -9,10 +10,14 @@ from renormalizer.utils import Quantity, CompressConfig, EvolveConfig, EvolveMet
 from renormalizer.utils.qutip_utils import get_clist, get_blist, get_hamiltonian, get_qnidx
 
 
-def test_autocorr():
+@pytest.mark.parametrize("scheme", (
+        3,
+        4,
+))
+def test_autocorr(scheme):
     ph = Phonon.simple_phonon(Quantity(1), Quantity(1), 2)
     mol = Mol(Quantity(0), [ph])
-    mol_list = MolList([mol] * 5, Quantity(1), 3)
+    mol_list = MolList([mol] * 5, Quantity(1), scheme)
     temperature = Quantity(50000, 'K')
     compress_config = CompressConfig(CompressCriteria.fixed, max_bonddim=24)
     evolve_config = EvolveConfig(EvolveMethod.tdvp_ps, adaptive=True, guess_dt=0.5, adaptive_rtol=1e-3)


### PR DESCRIPTION
- add method `copy` to `MolList`
- change the default behavior of `build empty qn` so that the `qnidx` is set to be the right-most site to be consistent with other normal MPS/MPO
- Add MPO `intersite` code for scheme 4 and modify related tests. Transport autocorr was unable to run in scheme 4 because of this.