### PR TITLE
Another basis set for multi electron on one site

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -26,7 +26,7 @@ Contents
    configs.rst
    mps.rst
    model.rst
-   utils.md
+   utils.rst
    develop.md
 
 

--- a/doc/source/utils.md
+++ b/doc/source/utils.md
@@ -1,1 +1,0 @@
-# some self-built tools

--- a/doc/source/utils.rst
+++ b/doc/source/utils.rst
@@ -1,0 +1,7 @@
+Some self-built tools
+*************************************
+
+Basis
+=====
+.. automodule:: renormalizer.utils.basis
+   :members:

--- a/renormalizer/model/mlist.py
+++ b/renormalizer/model/mlist.py
@@ -336,11 +336,7 @@ class MolList2:
         
         dipole = {}
         for imol, mol in enumerate(mol_list):
-            if mol_list.scheme < 4:
-                dipole[(f"e_{imol}", )] = mol.dipole
-            elif mol_list.scheme == 4:
-                dipole[(f"e_{imol}", "e_0")] = mol.dipole
-                dipole[("e_0", f"e_{imol}")] = mol.dipole
+            dipole[(f"e_{imol}", )] = mol.dipole
 
         mol_list2 = cls(order, basis, model, model_translator, dipole=dipole)
         mol_list2.map = mapping

--- a/renormalizer/model/mlist.py
+++ b/renormalizer/model/mlist.py
@@ -18,10 +18,6 @@ class ModelTranslator(Enum):
     """
     Available Translator from user input model to renormalizer's internal formats 
     """
-    # from MolList scheme1/2/3
-    Holstein_model_scheme123 = "Holstein Model Scheme123 (MolList)"
-    # from MolList scheme4
-    Holstein_model_scheme4 = "Holstein Model Scheme4 (MolList)"
     # from MolList sbm
     sbm = "Spin Boson Model (MolList)"
     # from MolList2 or MolList augmented with MolList2 parameters
@@ -99,12 +95,24 @@ class MolList2:
                 self.order[o] = i
 
         if isinstance(basis, list):
-            self.basis = basis
+            self.basis: List[ba.BasisSet] = basis
         else:
             assert isinstance(basis, dict)
-            self.basis = [None] * len(self.order)
+            order_value_set = set(self.order.values())
+            if min(order_value_set) != 0 or max(order_value_set) != len(order_value_set) - 1:
+                raise ValueError("order is not continuous integers from 0")
+            self.basis = [None] * (max(self.order.values()) + 1)
             for dof_name, dof_idx in self.order.items():
                 self.basis[dof_idx] = basis[dof_name]
+
+        for b in self.basis:
+            if b.multi_dof:
+                self.multi_dof_basis = True
+                break
+        else:
+            self.multi_dof_basis = False
+
+
         self.model = model
         self.model_translator = model_translator
         # array(n_e, n_e)
@@ -113,18 +121,6 @@ class MolList2:
         self.map = None
         # reusable mpos for the system
         self.mpos = dict()
-            
-    @property
-    def multi_electron(self):
-        for b in self.basis:
-            if isinstance(b, ba.BasisMultiElectron):
-                return True
-        return False
-    
-    @property
-    def multi_e_idx(self):
-        assert self.multi_electron
-        return self.order["e_0"]
 
     @property
     def pbond_list(self):
@@ -219,19 +215,12 @@ class MolList2:
         basis = []
         model = {}
         mapping = {}
-        
-        def e_idx(idx):
-            if mol_list.scheme < 4:
-                return idx
-            elif mol_list.scheme == 4:
-                # add the gs state
-                return idx + 1
 
         if mol_list.scheme < 4:
             idx = 0
             nv = 0
             for imol, mol in enumerate(mol_list):
-                order[f"e_{e_idx(imol)}"] = idx
+                order[f"e_{imol}"] = idx
                 if np.allclose(mol.tunnel, 0):
                     basis.append(ba.BasisSimpleElectron())
                 else:
@@ -266,11 +255,8 @@ class MolList2:
                     idx += 1
             
             for imol in range(mol_list.mol_num):
-                order[f"e_{e_idx(imol)}"] = n_left_ph
-            # the gs state
-            order["e_0"] = n_left_ph
-            basis.insert(n_left_ph,
-                         ba.BasisMultiElectron(mol_list.mol_num + 1, [0, ] + [1, ] * mol_list.mol_num))
+                order[f"e_{imol}"] = n_left_ph
+            basis.insert(n_left_ph, ba.BasisMultiElectronVac(mol_list.mol_num))
 
         else:
             raise ValueError(f"invalid mol_list.scheme: {mol_list.scheme}")
@@ -282,9 +268,9 @@ class MolList2:
             for imol in range(mol_list.mol_num):
                 for jmol in range(mol_list.mol_num):
                     if imol == jmol:
-                        model[(f"e_{e_idx(imol)}", f"e_{e_idx(jmol)}")] = {"J": mol_list[imol].elocalex + mol_list[imol].dmrg_e0}
+                        model[(f"e_{imol}", f"e_{jmol}")] = {"J": mol_list[imol].elocalex + mol_list[imol].dmrg_e0}
                     else:
-                        model[(f"e_{e_idx(imol)}", f"e_{e_idx(jmol)}")] = {"J": mol_list.j_matrix[imol, jmol]}
+                        model[(f"e_{imol}", f"e_{jmol}")] = {"J": mol_list.j_matrix[imol, jmol]}
             
             # vibration part
             model["I"] = {}
@@ -299,11 +285,11 @@ class MolList2:
             for imol, mol in enumerate(mol_list):
                 for iph, ph in enumerate(mol.dmrg_phs):
                     if np.allclose(ph.omega[0], ph.omega[1]):
-                        model[(f"e_{e_idx(imol)}", f"e_{e_idx(imol)}")][(mapping[(imol,iph)],)] \
+                        model[(f"e_{imol}", f"e_{imol}")][(mapping[(imol,iph)],)] \
                             = [(Op("x", 0), -ph.omega[1]**2*ph.dis[1])]
                     
                     else:
-                        model[(f"e_{e_idx(imol)}", f"e_{e_idx(imol)}")][(mapping[(imol,iph)],)] \
+                        model[(f"e_{imol}", f"e_{imol}")][(mapping[(imol,iph)],)] \
                             = [
                                 (Op("x^2", 0), 0.5*(ph.omega[1]**2-ph.omega[0]**2)),
                                 (Op("x", 0), -ph.omega[1]**2*ph.dis[1]),
@@ -316,11 +302,11 @@ class MolList2:
             for imol in range(mol_list.mol_num):
                 for jmol in range(mol_list.mol_num):
                     if imol == jmol:
-                        model[(f"e_{e_idx(imol)}",)] = \
+                        model[(f"e_{imol}",)] = \
                         [(Op(r"a^\dagger a", 0),
                             mol_list[imol].elocalex + mol_list[imol].dmrg_e0)]
                     else:
-                        model[(f"e_{e_idx(imol)}", f"e_{e_idx(jmol)}")] = \
+                        model[(f"e_{imol}", f"e_{jmol}")] = \
                             [(Op(r"a^\dagger", 1), Op("a", -1),
                                 mol_list.j_matrix[imol, jmol])]
             # vibration part
@@ -335,11 +321,11 @@ class MolList2:
             for imol, mol in enumerate(mol_list):
                 for iph, ph in enumerate(mol.dmrg_phs):
                     if np.allclose(ph.omega[0], ph.omega[1]):
-                        model[(f"e_{e_idx(imol)}", f"{mapping[(imol,iph)]}")] = [
+                        model[(f"e_{imol}", f"{mapping[(imol,iph)]}")] = [
                                 (Op(r"a^\dagger a", 0), Op("x", 0), -ph.omega[1]**2*ph.dis[1]),
                                 ]
                     else:
-                        model[(f"e_{e_idx(imol)}", f"{mapping[(imol,iph)]}")] = [
+                        model[(f"e_{imol}", f"{mapping[(imol,iph)]}")] = [
                                 (Op(r"a^\dagger a", 0), Op("x^2", 0), 0.5*(ph.omega[1]**2-ph.omega[0]**2)),
                                 (Op(r"a^\dagger a", 0), Op("x", 0), -ph.omega[1]**2*ph.dis[1]),
                                 ]
@@ -351,10 +337,10 @@ class MolList2:
         dipole = {}
         for imol, mol in enumerate(mol_list):
             if mol_list.scheme < 4:
-                dipole[(f"e_{e_idx(imol)}", )] = mol.dipole
+                dipole[(f"e_{imol}", )] = mol.dipole
             elif mol_list.scheme == 4:
-                dipole[(f"e_{e_idx(imol)}", "e_0")] = mol.dipole
-                dipole[("e_0", f"e_{e_idx(imol)}")] = mol.dipole
+                dipole[(f"e_{imol}", "e_0")] = mol.dipole
+                dipole[("e_0", f"e_{imol}")] = mol.dipole
 
         mol_list2 = cls(order, basis, model, model_translator, dipole=dipole)
         mol_list2.map = mapping
@@ -514,10 +500,10 @@ class MolList:
             #sbm
             self.model_translator = ModelTranslator.sbm
         else:
-            if self.scheme == 4:
-                self.model_translator = ModelTranslator.Holstein_model_scheme4
-            elif self.scheme < 4:
-                self.model_translator = ModelTranslator.Holstein_model_scheme123
+            if formula == "vibronic":
+                self.model_translator = ModelTranslator.vibronic_model
+            elif formula == "general":
+                self.model_translator = ModelTranslator.general_model
             else:
                 raise ValueError
     

--- a/renormalizer/mps/mpo.py
+++ b/renormalizer/mps/mpo.py
@@ -509,7 +509,7 @@ def _model_translator_general_model(mol_list, const=Quantity(0.)):
                         dof_name, dof_op = model_key[iop], op_term[iop]
                         dof_basis = basis[order[dof_name]]
                         if dof_basis.multi_dof and "_" not in dof_op.symbol:
-                            # add the index to the operator in multi elecron case
+                            # add the index to the operator in multi electron case
                             # for example, "a^\dagger a" on a single e_dof
                             # "a^\dagger" "a" on two different e_dofs
                             symbols.append(add_idx(dof_op.symbol, dof_name.split("_")[1]))

--- a/renormalizer/mps/mpo.py
+++ b/renormalizer/mps/mpo.py
@@ -508,7 +508,7 @@ def _model_translator_general_model(mol_list, const=Quantity(0.)):
                     for iop in iops:
                         dof_name, dof_op = model_key[iop], op_term[iop]
                         dof_basis = basis[order[dof_name]]
-                        if dof_basis.multi_dof:
+                        if dof_basis.multi_dof and "_" not in dof_op.symbol:
                             # add the index to the operator in multi elecron case
                             # for example, "a^\dagger a" on a single e_dof
                             # "a^\dagger" "a" on two different e_dofs
@@ -1487,6 +1487,7 @@ class Mpo(MatrixProduct):
         self.qnidx = qnidx
         self.qntot = qntot
         self.qn = mpo_qn
+        self.to_right = False
         
         # evaluate the symbolic mpo
         assert mol_list.basis is not None

--- a/renormalizer/mps/mpo.py
+++ b/renormalizer/mps/mpo.py
@@ -1,7 +1,12 @@
 import logging
+import copy
+import itertools
+from typing import List, Tuple, Union
+from collections import defaultdict, Counter
 
 import numpy as np
 import scipy
+import scipy.sparse
 
 from renormalizer.model import MolList, MolList2, ModelTranslator
 from renormalizer.model.ephtable import EphTable
@@ -19,11 +24,6 @@ from renormalizer.utils.elementop import (
 )
 from renormalizer.utils.utils import roundrobin
 
-import copy
-import itertools
-from typing import List, Tuple, Union
-from collections import defaultdict
-import scipy.sparse
 
 logger = logging.getLogger(__name__)
 
@@ -293,178 +293,6 @@ def symbolic_mpo(table, factor, algo="Hopcroft-Karp"):
     return mpo, mpoqn, qntot, qnidx
 
 
-def _model_translator_Holstein_model_scheme123(mol_list, const=Quantity(0.)):
-    r"""
-    construct a Frenkel-Holstein Model Hamiltonian operator table corresponding
-    to the scheme 1/2/3 but only with omega_e = omega_g and no 3rd order terms
-    
-    Args:
-        mol_list(class: MolList)
-        const (float, complex): constant added to the operator
-
-    Returns:
-        table, factor for `symbolic_mpo`
-    """
-    assert isinstance(mol_list, MolList)
-
-    # the site order: corresponds to scheme1/2/3
-
-    order = {}
-    idx = 0
-    for imol in range(mol_list.mol_num):
-        order[(imol,-1)] = idx
-        idx += 1
-        for jph in range(mol_list[imol].n_dmrg_phs):
-            order[(imol,jph)] = idx
-            idx += 1
-    
-    nsite = len(order)
-    
-    factor = []
-    table = []
-
-    #electronic term
-    for imol in range(mol_list.mol_num):
-        for jmol in range(mol_list.mol_num):
-            ta = [Op.identity() for i in range(nsite)]
-            if imol == jmol:
-                ta[order[(imol,-1)]] = Op(r"a^\dagger a", 0)
-                factor.append(mol_list[imol].elocalex + mol_list[imol].dmrg_e0)
-            else:
-                J = mol_list.j_matrix[imol, jmol]
-                # scheme3 
-                if np.allclose(J, 0.0):
-                    continue
-                ta[order[(imol,-1)]] = Op(r"a^\dagger", 1)
-                ta[order[(jmol,-1)]] = Op("a", -1)
-                factor.append(J)
-
-            table.append(ta)
-    
-    # electron-vibration term
-    for imol in range(mol_list.mol_num):
-        for iph in range(mol_list[imol].n_dmrg_phs):
-            ta = [Op.identity() for i in range(nsite)]
-            ta[order[(imol,-1)]] = Op(r"a^\dagger a", 0)
-            ta[order[(imol,iph)]] = Op("x", 0)
-            table.append(ta)
-
-            factor.append(-mol_list[imol].dmrg_phs[iph].dis[1]*mol_list[imol].dmrg_phs[iph].omega[0]**2)
-
-    # vibration term 
-    for imol in range(mol_list.mol_num):
-        for iph in range(mol_list[imol].n_dmrg_phs):
-            assert mol_list[imol].dmrg_phs[iph].is_simple
-            # kinetic
-            ta = [Op.identity() for i in range(nsite)]
-            ta[order[(imol,iph)]] = Op("p^2",0)
-            factor.append(0.5)
-            table.append(ta)
-            # potential
-            ta = [Op.identity() for i in range(nsite)]
-            ta[order[(imol,iph)]] = Op("x^2",0)
-            factor.append(0.5*mol_list[imol].dmrg_phs[iph].omega[0]**2)
-            table.append(ta)
-    
-    # const
-    if not np.allclose(const.as_au(), 0.):
-        ta = [Op.identity() for i in range(nsite)]
-        factor.append(const.as_au())
-        table.append(ta)
-
-    factor = np.array(factor)
-    logger.debug(f"# of operator terms: {len(table)}")
-    
-    return table, factor
-
-
-def _model_translator_Holstein_model_scheme4(mol_list, const=Quantity(0.)):
-    r"""
-    construct a Frenkel-Holstein Model Hamiltonian operator table corresponding
-    to the scheme 4 but only with omega_e = omega_g and no 3rd order terms
-    
-    Args:
-        mol_list(class: MolList)
-        const (float, complex): constant added to the operator
-
-    Returns:
-        table, factor for `symbolic_mpo`
-    """
-    
-    assert isinstance(mol_list, MolList)
-
-    # the site order corresponds to scheme4
-    order = {}
-    nmol = mol_list.mol_num
-    n_left_mol = nmol // 2
-    
-    idx = 0
-    n_left_ph = 0
-    for imol, mol in enumerate(mol_list):
-        for iph, ph in enumerate(mol.dmrg_phs):
-            assert ph.is_simple
-            if imol < n_left_mol:
-                order[(imol,iph)] = idx
-                n_left_ph += 1
-            else:
-                order[(imol,iph)] = idx+1
-            idx += 1
-    order["e"] = n_left_ph
-        
-    nsite = len(order)
-    
-    factor = []
-    table = []
-    
-    # electronic term
-    for imol in range(mol_list.mol_num):
-        for jmol in range(mol_list.mol_num):
-            ta = [Op.identity() for i in range(nsite)]
-            ta[order["e"]] = Op(rf"a^\dagger_{imol+1} a_{jmol+1}", 0)
-            if imol == jmol:
-                factor.append(mol_list[imol].elocalex + mol_list[imol].dmrg_e0)
-            else:
-                factor.append(mol_list.j_matrix[imol, jmol])
-
-            table.append(ta)
-    
-    # electron-vibration term
-    for imol in range(mol_list.mol_num):
-        for iph in range(mol_list[imol].n_dmrg_phs):
-            ta = [Op.identity() for i in range(nsite)]
-            ta[order["e"]] = Op(rf"a^\dagger_{imol+1} a_{imol+1}", 0)
-            ta[order[(imol,iph)]] = Op("x", 0)
-            table.append(ta)
-
-            factor.append(-mol_list[imol].dmrg_phs[iph].dis[1]*mol_list[imol].dmrg_phs[iph].omega[0]**2)
-
-    # vibration term 
-    for imol in range(mol_list.mol_num):
-        for iph in range(mol_list[imol].n_dmrg_phs):
-            assert mol_list[imol].dmrg_phs[iph].is_simple
-            # kinetic
-            ta = [Op.identity() for i in range(nsite)]
-            ta[order[(imol,iph)]] = Op("p^2", 0)
-            factor.append(0.5)
-            table.append(ta)
-            # potential
-            ta = [Op.identity() for i in range(nsite)]
-            ta[order[(imol,iph)]] = Op("x^2", 0)
-            factor.append(0.5*mol_list[imol].dmrg_phs[iph].omega[0]**2)
-            table.append(ta)
-    
-    # const
-    if not np.allclose(const.as_au(), 0.):
-        ta = [Op.identity() for i in range(nsite)]
-        factor.append(const.as_au())
-        table.append(ta)
-
-    factor = np.array(factor)
-    logger.debug(f"# of operator terms: {len(table)}")
-    
-    return table, factor
-
-
 def _model_translator_sbm(mol_list, const=Quantity(0.)):
     """
     construct a spin-boson model operator table
@@ -642,6 +470,7 @@ def _model_translator_general_model(mol_list, const=Quantity(0.)):
     table = []
     nsite = mol_list.nsite
     order = mol_list.order
+    basis = mol_list.basis
     model = mol_list.model
     
     # clean up 
@@ -656,59 +485,64 @@ def _model_translator_general_model(mol_list, const=Quantity(0.)):
     # is ("e_0",):[(Op("a^\dagger_0 a_1"), factor)] 
     
     model_new = defaultdict(list)
-    for key, value in model.items():
-        
-        dof_site_idx = [order[k] for k in key]
-        
-        if len(dof_site_idx) != len(set(dof_site_idx)) or mol_list.multi_electron:
+    for model_key, model_value in model.items():
+
+        # site index of the dofs for each term in the model
+        dof_site_idx = [order[k] for k in model_key]
+
+        dof_site_idx_unique = len(dof_site_idx) == len(set(dof_site_idx))
+        if not dof_site_idx_unique or mol_list.multi_dof_basis:
+            # keys: site index; values: index of the dofs (in terms of the model key) on the site index
             dofdict = defaultdict(list)
-            for idof, dof in enumerate(key):
+            for idof, dof in enumerate(model_key):
                 dofdict[order[dof]].append(idof)
-            
+
             new_key = tuple(dofdict.keys())
             new_value = []
-            for term in value:
+            for op_term in model_value:
+                # op_term is of format (Op, Op,..., float)
                 new_term = []
-                for v in dofdict.values():
+                for iops in dofdict.values():
                     symbols = []
                     qn = 0
-                    for iop in v:
-                        if list(order.values()).count(order[key[iop]]) > 1:
+                    for iop in iops:
+                        dof_name, dof_op = model_key[iop], op_term[iop]
+                        dof_basis = basis[order[dof_name]]
+                        if dof_basis.multi_dof:
                             # add the index to the operator in multi elecron case
-                            # two cases, one is "a^\dagger a" on a single e_dof
-                            # another is "a^\dagger" "a" on two different e_dof
-                            symbols.append(add_idx(term[iop].symbol,
-                                key[iop].split("_")[1]))
+                            # for example, "a^\dagger a" on a single e_dof
+                            # "a^\dagger" "a" on two different e_dofs
+                            symbols.append(add_idx(dof_op.symbol, dof_name.split("_")[1]))
                         else:
-                            symbols.append(term[iop].symbol)
-                        qn += term[iop].qn
+                            symbols.append(dof_op.symbol)
+                        qn += dof_op.qn
                     op = Op(" ".join(symbols), qn)
                     new_term.append(op)
 
-                if isinstance(term[-1], Quantity):
+                if isinstance(op_term[-1], Quantity):
                     raise TypeError("term factor should be float instead of Quantity")
-                new_term.append(term[-1])
+                new_term.append(op_term[-1])
                 new_value.append(tuple(new_term))
 
             model_new[new_key] += new_value
         else:
-            model_new[tuple(dof_site_idx)] += value
+            model_new[tuple(dof_site_idx)] += model_value
 
     model = model_new
 
-    for dof, value in model.items():
-        op_factor = np.array([term[-1] for term in value])
+    for dof, model_value in model.items():
+        op_factor = np.array([term[-1] for term in model_value])
         nonzero_idx = np.nonzero(np.isclose(op_factor, 0, rtol=1e-5, atol=1e-8) == 0)[0]
         
         mapping = {j:i for i,j in enumerate(dof)}
         for idx in nonzero_idx:
-            term = value[idx]
+            op_term = model_value[idx]
             # note that all the list element point to the same identity
             # it will not destroy the following operation since identity is not changed
             identity = Op.identity()
-            ta = [term[mapping[isite]] if isite in mapping.keys() else identity for isite in range(nsite)]
+            ta = [op_term[mapping[isite]] if isite in mapping.keys() else identity for isite in range(nsite)]
             table.append(ta)
-            factor.append(term[-1])
+            factor.append(op_term[-1])
         
     # const
     if not np.allclose(const.as_au(), 0.):
@@ -1095,9 +929,6 @@ class Mpo(MatrixProduct):
     def onsite(cls, mol_list: MolList, opera, dipole=False, mol_idx_set=None):
         
         if isinstance(mol_list, MolList2):
-            # the onsite method is tricky for multi electron case in general
-            # for example the creation operator "a^\dagger" is not well defined
-            assert not mol_list.multi_electron
             qn_dict= {"a":-1, r"a^\dagger":1, r"a^\dagger a":0, "sigma_x":0}
             if mol_idx_set is None:
                 mol_idx_set = range(len(mol_list.e_dofs))
@@ -1633,8 +1464,6 @@ class Mpo(MatrixProduct):
         assert len(self) == 0
     
         translator_list = {
-                ModelTranslator.Holstein_model_scheme123: _model_translator_Holstein_model_scheme123,
-                ModelTranslator.Holstein_model_scheme4: _model_translator_Holstein_model_scheme4,
                 ModelTranslator.sbm: _model_translator_sbm,
                 ModelTranslator.vibronic_model: _model_translator_vibronic_model,
                 ModelTranslator.general_model: _model_translator_general_model

--- a/renormalizer/mps/mps.py
+++ b/renormalizer/mps/mps.py
@@ -3,7 +3,7 @@
 import logging
 from functools import wraps
 from typing import Union, List, Dict
-from collections import Counter
+from collections import Counter, deque
 
 import scipy
 from scipy import stats
@@ -1509,11 +1509,11 @@ class Mps(MatrixProduct):
                 self.mol_list.mpos[key] = mpos
             else:
                 mpos = self.mol_list.mpos[key]
-            expectations = self.expectations(mpos)
+            expectations = deque(self.expectations(mpos))
             reduced_density_matrix = np.zeros((n_e, n_e), dtype=backend.complex_dtype)
             for idx in range(n_e):
                 for jdx in range(idx, n_e):
-                    reduced_density_matrix[idx, jdx] = expectations[n_e * idx + jdx]
+                    reduced_density_matrix[idx, jdx] = expectations.popleft()
                     reduced_density_matrix[jdx, idx] = np.conj(reduced_density_matrix[idx, jdx])
 
         elif isinstance(self.mol_list, MolList):

--- a/renormalizer/mps/tests/test_evolve.py
+++ b/renormalizer/mps/tests/test_evolve.py
@@ -20,7 +20,7 @@ def f(mol_list, run_qutip=True):
     mpo = Mpo(mol_list, offset=Quantity(e))
     
     if run_qutip:
-        # calculate exact result in ZT. FT result is exactly the same
+        # calculate result in ZT. FT result is exactly the same
         TIME_LIMIT = 10
         QUTIP_STEP = 0.01
         N_POINTS = TIME_LIMIT / QUTIP_STEP + 1

--- a/renormalizer/mps/tests/test_mpo.py
+++ b/renormalizer/mps/tests/test_mpo.py
@@ -137,7 +137,10 @@ def test_phonon_onsite():
 from renormalizer.tests.parameter_PBI import construct_mol
 
 @pytest.mark.parametrize("mol_list", (mol_list, construct_mol(10,10,0)))
-@pytest.mark.parametrize("scheme", (123, 4))
+@pytest.mark.parametrize("scheme", (
+        123,
+        4,
+))
 def test_general_mpo_MolList(mol_list, scheme):
     
     if scheme == 4:

--- a/renormalizer/mps/tests/test_mps.py
+++ b/renormalizer/mps/tests/test_mps.py
@@ -4,6 +4,8 @@ import numpy as np
 import pytest
 
 from renormalizer.mps import Mps, Mpo
+from renormalizer.model import MolList2, ModelTranslator
+from renormalizer.utils.basis import BasisSHO, BasisMultiElectronVac, BasisMultiElectron, BasisSimpleElectron, Op
 from renormalizer.tests import parameter
 
 
@@ -31,3 +33,37 @@ def test_expectations(mpos):
     e2 = random.expectations(mpos, opt=False)
 
     assert np.allclose(e1, e2)
+
+
+def check_reduced_density_matrix(order, basis):
+    mol_list = MolList2(order, basis, {}, ModelTranslator.general_model)
+    mps = Mps.random(mol_list, 1, 20)
+    rdm = mps.calc_reduced_density_matrix().real
+    assert np.allclose(np.diag(rdm), mps.e_occupations)
+    # only test a sample. Should be enough.
+    mpo = Mpo.general_mpo(mol_list, model={(f"e_0", f"e_3"): [(Op(r"a^\dagger", 1), Op("a", -1), 1.0)]},
+                          model_translator=ModelTranslator.general_model)
+    assert rdm[-1][0] == pytest.approx(mps.expectation(mpo))
+
+
+def test_reduced_density_matrix():
+    # case one: simple electron
+    order = {"e_0": 0, "v_0": 1, "e_1": 2, "v_1": 3, "e_2": 4, "v_2": 5, "e_3": 6, "v_3": 7}
+    basis = [BasisSimpleElectron(), BasisSHO(1, 2)] * 4
+    check_reduced_density_matrix(order, basis)
+
+    # case two: multi electron
+    order = {"e_0": 0, "v_0": 1, "e_1": 0, "v_1": 2, "e_2": 0, "v_2": 3, "e_3": 0, "v_3": 4}
+    basis = [BasisMultiElectron(4, [1,1,1,1])] + [BasisSHO(1, 2)] * 4
+    check_reduced_density_matrix(order, basis)
+
+    # case three: MultiElectronVac on multiple sites
+    order = {"e_0": 0, "v_0": 1, "e_1": 0, "v_1": 2, "e_2": 3, "v_2": 4, "e_3": 3, "v_3": 5}
+    basis = [BasisMultiElectronVac(2, dof_idx=[0, 1])] + [BasisSHO(1, 2)] * 2 \
+            + [BasisMultiElectronVac(2, dof_idx=[2, 3])] +[BasisSHO(1, 2)] * 2
+    check_reduced_density_matrix(order, basis)
+
+
+
+
+

--- a/renormalizer/transport/autocorr.py
+++ b/renormalizer/transport/autocorr.py
@@ -22,6 +22,7 @@ class TransportAutoCorr(TdMpsJob):
             evolve_config=None, dump_dir: str=None, job_name: str=None, properties: Property = None,):
         self.mol_list = mol_list
         self.h_mpo = Mpo(mol_list)
+        logger.info(f"Bond dim of h_mpo: {self.h_mpo.bond_dims}")
         if j_oper is None:
             self.j_oper = self._construct_flux_operator()
         else:
@@ -72,11 +73,6 @@ class TransportAutoCorr(TdMpsJob):
             j_oper = compressed_sum(j_list, batchsize=10)
         
         elif isinstance(self.mol_list, MolList2):
-            
-            # In multi_electron case, the zero-exciton state is not guaranteed to be added as
-            # scheme4, it is more flexiable depending on the definition of
-            # mol_list.order and mol_list.model
-            assert not self.mol_list.multi_electron
             
             e_nsite = self.mol_list.n_edofs
             model = {}

--- a/renormalizer/transport/tests/test_autocorr.py
+++ b/renormalizer/transport/tests/test_autocorr.py
@@ -10,10 +10,13 @@ from renormalizer.utils import Quantity, CompressConfig, EvolveConfig, EvolveMet
 from renormalizer.utils.qutip_utils import get_clist, get_blist, get_hamiltonian, get_qnidx
 
 
-@pytest.mark.parametrize("scheme, mollist2", (
-        [3, False],
-        [4, False],
-        [3, True],
+@pytest.mark.parametrize("scheme", (
+        3,
+        4,
+))
+@pytest.mark.parametrize("mollist2", (
+        True,
+        False,
 ))
 def test_autocorr(scheme, mollist2):
     ph = Phonon.simple_phonon(Quantity(1), Quantity(1), 2)

--- a/renormalizer/utils/basis.py
+++ b/renormalizer/utils/basis.py
@@ -159,6 +159,8 @@ class BasisMultiElectron(BasisSet):
                 mat = np.eye(self.nbas)
             elif op_symbol[0] == "a" or op_symbol[0] == r"a^\dagger":
                 raise ValueError(f"op_symbol:{op_symbol} is not supported. Try use BasisMultiElectronVac.")
+            else:
+                raise ValueError(f"op_symbol:{op_symbol} is not supported")
             
         elif len(op_symbol) == 2:
             op_symbol1, op_symbol2 = op_symbol
@@ -172,7 +174,7 @@ class BasisMultiElectron(BasisSet):
             elif op_symbol1_term == r"a" and op_symbol2_term == r"a^\dagger":
                 mat[int(op_symbol2_idx), int(op_symbol1_idx)] = 1.
             else:
-                assert False
+                raise ValueError(f"op_symbol:{op_symbol} is not supported")
         else:
             raise ValueError(f"op_symbol:{op_symbol} is not supported")
 
@@ -190,7 +192,7 @@ class BasisMultiElectronVac(BasisSet):
         nstate (int): the number of electronic states without counting the vacuum state.
         dof_idx (list): the indices of the electronic dofs used to define the whole model
         that are represented by this basis. The default value is ``list(range(nstate))``.
-        The arg is necessary when you have multiple basis of this class in the model.
+        The arg is necessary when more than one basis of this class present in the model.
     """
 
     def __init__(self, nstate, dof_idx=None):
@@ -217,7 +219,6 @@ class BasisMultiElectronVac(BasisSet):
 
         op_symbol = op_symbol.split(" ")
 
-        mat = None
         if len(op_symbol) == 1:
             op_symbol = op_symbol[0]
             if op_symbol == "I":
@@ -229,6 +230,8 @@ class BasisMultiElectronVac(BasisSet):
                     mat[op_symbol_idx, 0] = 1.
                 elif op_symbol_term == r"a":
                     mat[0, op_symbol_idx] = 1.
+                else:
+                    raise ValueError(f"op_symbol:{op_symbol} is not supported")
 
         elif len(op_symbol) == 2:
             op_symbol1, op_symbol2 = op_symbol
@@ -241,8 +244,9 @@ class BasisMultiElectronVac(BasisSet):
                 mat[op_symbol1_idx, op_symbol2_idx] = 1.
             elif op_symbol1_term == r"a" and op_symbol2_term == r"a^\dagger":
                 mat[op_symbol2_idx, op_symbol1_idx] = 1.
-
-        if mat is None:
+            else:
+                raise ValueError(f"op_symbol:{op_symbol} is not supported")
+        else:
             raise ValueError(f"op_symbol:{op_symbol} is not supported")
 
         return mat * op_factor

--- a/renormalizer/vibronic/tests/test_pyr4.py
+++ b/renormalizer/vibronic/tests/test_pyr4.py
@@ -193,8 +193,14 @@ def vibronic_to_general(model):
     return new_model
 
 
-@pytest.mark.parametrize("multi_e", (False, True))
-@pytest.mark.parametrize("translator", (ModelTranslator.vibronic_model, ModelTranslator.general_model))
+@pytest.mark.parametrize("multi_e", (
+        False,
+        True,
+))
+@pytest.mark.parametrize("translator", (
+        ModelTranslator.vibronic_model,
+        ModelTranslator.general_model,
+))
 def test_pyr_4mode(multi_e, translator):
 
     order, basis, vibronic_model = construct_vibronic_model(multi_e)


### PR DESCRIPTION
Solves #89 .
Some points worth noting:
-  `Holstein_model_scheme123` and `Holstein_model_scheme4` in `ModelTranslator` are removed because in `MolList2` these schemes are firstly transformed into general model (or vibronic model) for future MPO construction. 
- The new basis is designed to work with multiple multi-e bases in the same model. The feature has already been put into use for a ladder-shaped Peierls Hamiltonian. This is why `dof_idx_map` is required for the basis.
- The special logic for reduced density matrix calculation when multiple e dofs are on the same site is simplified owing to the new expectation calculation routine #84 .