### PR TITLE
A quick bugfix in krylov matrix exponential

### DIFF
--- a/renormalizer/lib/krylov/krylov.py
+++ b/renormalizer/lib/krylov/krylov.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 def _expm_krylov(alpha, beta, V, v_norm, dt):
-    # diagonalize Hessenberg matrix
+    # diagonalize Hessenberg matrix (tridiagonal matrix for hermitian matrix A)
     try:
         w_hess, u_hess = eigh_tridiagonal(alpha, beta)
     except np.linalg.LinAlgError:
@@ -28,6 +28,7 @@ def expm_krylov(Afunc, dt, vstart: xp.ndarray, block_size=50):
     """
     Compute Krylov subspace approximation of the matrix exponential
     applied to input vector: `expm(dt*A)*v`.
+    A is a hermitian matrix.
     Reference:
         M. Hochbruck and C. Lubich
         On Krylov subspace approximations to the matrix exponential operator
@@ -47,15 +48,22 @@ def expm_krylov(Afunc, dt, vstart: xp.ndarray, block_size=50):
     V[0] = vstart
     res = None
 
-    for j in range(len(vstart) - 1):
-        if len(V) - 2 == j:
+    for j in range(len(vstart)):
+        
+        w = Afunc(V[j])
+        alpha[j] = xp.vdot(w, V[j]).real
+
+        if j == len(vstart)-1:
+            logger.debug("the krylov subspace is equal to the full space")
+            return _expm_krylov(alpha[:j+1], beta[:j], V[:j+1, :].T, nrmv, dt), j+1
+        
+        if len(V) == j+1:
             V, old_V = xp.empty((len(V) + block_size, len(vstart)), dtype=vstart.dtype), V
             V[:len(old_V)] = old_V
             del old_V
             alpha = np.concatenate([alpha, np.zeros(block_size)])
             beta = np.concatenate([beta, np.zeros(block_size)])
-        w = Afunc(V[j])
-        alpha[j] = xp.vdot(w, V[j]).real
+
         w -= alpha[j]*V[j] + (beta[j-1]*V[j-1] if j > 0 else 0)
         beta[j] = xp.linalg.norm(w)
         if beta[j] < 100*len(vstart)*np.finfo(float).eps:
@@ -69,6 +77,5 @@ def expm_krylov(Afunc, dt, vstart: xp.ndarray, block_size=50):
             else:
                 res = new_res
         V[j + 1] = w / beta[j]
-    return _expm_krylov(alpha[:j+1], beta[:j], V[:j+1].T, nrmv, dt), j+1
 
 

--- a/renormalizer/lib/tests/test_krylov.py
+++ b/renormalizer/lib/tests/test_krylov.py
@@ -1,14 +1,18 @@
 # -*- coding: utf-8 -*-
 
+
+from renormalizer.mps.backend import xp
+from renormalizer.lib import expm_krylov
 import pytest
 import numpy as np
 from scipy.linalg import expm
 
-from renormalizer.mps.backend import xp
-from renormalizer.lib import expm_krylov
-
 
 @pytest.mark.parametrize("N", (
+    1,
+    2,
+    4,
+    10,
     200,
     800
 ))
@@ -18,6 +22,8 @@ def test_expm(N, imag, block_size):
     a1 = np.random.rand(N, N) / N
     if imag:
         a1 = a1 + np.random.rand(N, N) / N / 1j
+    a1 += a1.T.conj()
+    
     a2 = xp.array(a1)
     v = np.random.rand(N)
     if imag:


### PR DESCRIPTION
The original implementation has a bug when the size of krylov space is equal to the full space.
This bug will show up when the size of the full space is small.
For example dim=1, alpha is wrong to be [0] after merging  PR #94 where I initialize `j=0`.
dim=2,  the size of the tridiagonal matrix is wrong to be 1.

It is fixed in this PR.