### PR TITLE
maintainance work

### DIFF
--- a/renormalizer/cv/zerot.py
+++ b/renormalizer/cv/zerot.py
@@ -153,11 +153,6 @@ class SpectraZtCV(SpectraCv):
             second_L = asxp(second_LR[isite - 2])
             second_R = asxp(second_LR[isite])
 
-        if self.cv_mps.to_right:
-            system = 'L'
-        else:
-            system = 'R'
-
         # this part just be similar with ground state calculation
         qnbigl, qnbigr, qnmat = self.cv_mps._get_big_qn(cidx)
         xshape = qnmat.shape

--- a/renormalizer/lib/krylov/krylov.py
+++ b/renormalizer/lib/krylov/krylov.py
@@ -68,7 +68,7 @@ def expm_krylov(Afunc, dt, vstart: xp.ndarray, block_size=50):
         w -= alpha[j]*V[j] + (beta[j-1]*V[j-1] if j > 0 else 0)
         beta[j] = xp.linalg.norm(w)
         if beta[j] < 100*len(vstart)*np.finfo(float).eps:
-            logger.warning(f'beta[{j}] ~= 0 encountered during Lanczos iteration.')
+            # logger.warning(f'beta[{j}] ~= 0 encountered during Lanczos iteration.')
             return _expm_krylov(alpha[:j+1], beta[:j], V[:j+1, :].T, nrmv, dt), j+1
 
         if 3 < j and j % 2 == 0:

--- a/renormalizer/model/mlist.py
+++ b/renormalizer/model/mlist.py
@@ -16,7 +16,7 @@ from renormalizer.utils import basis as ba
 
 class ModelTranslator(Enum):
     """
-    Available Translator from user input model to renormalizer's internal formats 
+    Available Translator from user input model to renormalizer's internal formats  
     """
     # from MolList sbm
     sbm = "Spin Boson Model (MolList)"

--- a/renormalizer/model/mlist.py
+++ b/renormalizer/model/mlist.py
@@ -16,7 +16,7 @@ from renormalizer.utils import basis as ba
 
 class ModelTranslator(Enum):
     """
-    Available Translator from user input model to renormalizer's internal formats  
+    Available Translator from user input model to renormalizer's internal formats
     """
     # from MolList sbm
     sbm = "Spin Boson Model (MolList)"

--- a/renormalizer/mps/gs.py
+++ b/renormalizer/mps/gs.py
@@ -164,10 +164,8 @@ def optimize_mps_dmrg(mps, mpo):
             
             if mps.to_right:
                 lmethod, rmethod = "System", "Enviro"
-                system = "L"
             else:
                 lmethod, rmethod = "Enviro", "System"
-                system = "R"
 
             if method == "1site":
                 lidx = imps - 1

--- a/renormalizer/mps/matrix.py
+++ b/renormalizer/mps/matrix.py
@@ -310,6 +310,3 @@ def asxp(array: Union[np.ndarray, xp.ndarray, Matrix]) -> xp.ndarray:
         assert isinstance(array, np.ndarray)
         return array
     return xp.asarray(array)
-
-
-class EmptyMatrixError(Exception): pass

--- a/renormalizer/mps/mp.py
+++ b/renormalizer/mps/mp.py
@@ -530,10 +530,8 @@ class MatrixProduct:
                 
                 if mps.to_right:
                     lmethod, rmethod = "System", "Enviro"
-                    system = "L"
                 else:
                     lmethod, rmethod = "Enviro", "System"
-                    system = "R"
 
                 if method == "1site":
                     lidx = imps - 1
@@ -980,9 +978,6 @@ class MatrixProduct:
     def append(self, array):
         new_mt = self._array2mt(array, len(self))
         self._mp.append(new_mt)
-
-    def clear(self):
-        self._mp.clear()
     
     def __str__(self):
         template_str = "current size: {}, Matrix product bond dim:{}"

--- a/renormalizer/mps/mpo.py
+++ b/renormalizer/mps/mpo.py
@@ -11,7 +11,7 @@ import scipy.sparse
 from renormalizer.model import MolList, MolList2, ModelTranslator
 from renormalizer.model.ephtable import EphTable
 from renormalizer.mps.backend import xp
-from renormalizer.mps.matrix import moveaxis, tensordot, asnumpy, EmptyMatrixError
+from renormalizer.mps.matrix import moveaxis, tensordot, asnumpy
 from renormalizer.mps.mp import MatrixProduct
 from renormalizer.mps import svd_qn
 from renormalizer.mps.lib import update_cv
@@ -2017,15 +2017,12 @@ class Mpo(MatrixProduct):
             new_mps.canonicalise()
         return new_mps
 
-    def contract(self, mps, check_emtpy=False, algo="svd"):
+    def contract(self, mps, algo="svd"):
         r""" an approximation of mpo @ mps/mpdm/mpo
         
         Parameters
         ----------
         mps : `Mps`, `Mpo`, `MpDm`
-        check_emtpy : bool, optional
-            Check if the obtained new mps has zero local matrix. Default is
-            ``False``.
         algo: str, optional
             The algorithm to compress mpo @ mps/mpdm/mpo.  It could be ``svd``
             (default) and ``variational``. 
@@ -2047,18 +2044,10 @@ class Mpo(MatrixProduct):
         if algo == "svd":
             # mapply->canonicalise->compress
             new_mps = self.apply(mps)
-            if check_emtpy:
-                for mt in new_mps:
-                    if mt.nearly_zero():
-                        raise EmptyMatrixError
             new_mps.canonicalise()
             new_mps.compress()
         elif algo == "variational":
             new_mps = mps.variational_compress(self)
-            if check_emtpy:
-                for mt in new_mps:
-                    if mt.nearly_zero():
-                        raise EmptyMatrixError
         else:
             assert False
 

--- a/renormalizer/mps/supermpo.py
+++ b/renormalizer/mps/supermpo.py
@@ -38,7 +38,7 @@ class SuperLiouville(Mpo):
         summed_term = compressed_sum(applied_terms)
         bdb_operator: Mpo = mp.mol_list.get_mpos("lindblad_bdb", calc_lindblad_bdb)
         # any room for optimization? are there any simple relations between the two terms?
-        lindblad = summed_term - 0.5 * (bdb_operator.contract(mp, True) + mp.contract(bdb_operator, True))
+        lindblad = summed_term - 0.5 * (bdb_operator.contract(mp) + mp.contract(bdb_operator))
         ret = no_dissipation + 1j * self.dissipation * lindblad
         return ret
 

--- a/renormalizer/mps/supermpo.py
+++ b/renormalizer/mps/supermpo.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from typing import List, Tuple
 
-from renormalizer.mps.matrix import EmptyMatrixError
 from renormalizer.mps.mpo import Mpo
 from renormalizer.mps.mpdm import MpDmFull
 from renormalizer.mps.lib import compressed_sum
@@ -39,10 +38,7 @@ class SuperLiouville(Mpo):
         summed_term = compressed_sum(applied_terms)
         bdb_operator: Mpo = mp.mol_list.get_mpos("lindblad_bdb", calc_lindblad_bdb)
         # any room for optimization? are there any simple relations between the two terms?
-        try:
-            lindblad = summed_term - 0.5 * (bdb_operator.contract(mp, True) + mp.contract(bdb_operator, True))
-        except EmptyMatrixError:
-            lindblad = summed_term
+        lindblad = summed_term - 0.5 * (bdb_operator.contract(mp, True) + mp.contract(bdb_operator, True))
         ret = no_dissipation + 1j * self.dissipation * lindblad
         return ret
 

--- a/renormalizer/transport/kubo.py
+++ b/renormalizer/transport/kubo.py
@@ -68,7 +68,7 @@ class TransportKubo(TdMpsJob):
             Zero temperature is not supported.
         distance_matrix (np.ndarray): two-dimensional array :math:`D_{ij} = P_i - P_j` representing
             distance between the :math:`i` th electronic degree of freedom and the :math:`j` th degree of freedom.
-            The parameter takes the roll of :math:`\hat P` and can better handle periodic boundary condition.
+            The parameter takes the role of :math:`\hat P` and can better handle periodic boundary condition.
             The default value is ``None`` in which case the distance matrix is constructed assuming the system
             is a one-dimensional chain.
 
@@ -241,11 +241,13 @@ class TransportKubo(TdMpsJob):
         e = mpdm.expectation(self.h_mpo)
         self.h_mpo = Mpo(self.mol_list, offset=Quantity(e))
         mpdm.evolve_config = self.evolve_config
+        logger.debug("Applying current operator")
         ket_mpdm = self.j_oper.contract(mpdm).canonical_normalize()
         bra_mpdm = mpdm.copy()
         if self.j_oper2 is None:
             return BraKetPair(bra_mpdm, ket_mpdm, self.j_oper)
         else:
+            logger.debug("Applying the second current operator")
             ket_mpdm2 = self.j_oper2.contract(mpdm).canonical_normalize()
             return BraKetPair(bra_mpdm, ket_mpdm, self.j_oper), BraKetPair(bra_mpdm, ket_mpdm2, self.j_oper2)
 

--- a/renormalizer/transport/tests/test_dynamics.py
+++ b/renormalizer/transport/tests/test_dynamics.py
@@ -55,7 +55,7 @@ def test_ft_init_state():
     "method, evolve_dt, nsteps, rtol",
     (
         (EvolveMethod.prop_and_compress, 4, 25, 1e-3),
-        (EvolveMethod.tdvp_ps, 2, 100, 1e-3),
+        (EvolveMethod.tdvp_ps, 2, 50, 1e-3),
     ),
 )
 @pytest.mark.parametrize("scheme", (3, 4))
@@ -113,49 +113,6 @@ def assert_iterable_equal(i1, i2):
     for ii1, ii2 in zip(i1, i2):
         assert_iterable_equal(ii1, ii2)
 
-
-@pytest.mark.parametrize(
-    "mol_num, j_constant_value, elocalex_value, ph_info, ph_phys_dim, evolve_dt, nsteps, temperature",
-    (
-        [3, 0.8, 3.87e-3, [[1345.6738910804488, 16.274571056529368]], 4, 2, 15, 0],
-        [3, 0.8, 3.87e-3, [[1345.6738910804488, 16.274571056529368]], 4, 2, 15, 100],
-    ),
-)
-def test_reduced_density_matrix(
-    mol_num,
-    j_constant_value,
-    elocalex_value,
-    ph_info,
-    ph_phys_dim,
-    evolve_dt,
-    nsteps,
-    temperature,
-):
-    ph_list = [
-        Phonon.simple_phonon(
-            Quantity(omega, "cm^{-1}"), Quantity(displacement, "a.u."), ph_phys_dim
-        )
-        for omega, displacement in ph_info
-    ]
-    mol_list3 = MolList(
-        [Mol(Quantity(elocalex_value, "a.u."), ph_list)] * mol_num,
-        Quantity(j_constant_value, "eV"),
-        scheme=3,
-    )
-
-    ct3 = ChargeDiffusionDynamics(
-        mol_list3, temperature=Quantity(temperature, "K"), stop_at_edge=False, rdm=True
-    )
-    ct3.evolve(evolve_dt, nsteps)
-
-    mol_list4 = mol_list3.switch_scheme(4)
-    ct4 = ChargeDiffusionDynamics(
-        mol_list4, temperature=Quantity(temperature, "K"), stop_at_edge=False, rdm=True
-    )
-    ct4.evolve(evolve_dt, nsteps)
-    for rdm3, rdm4, e in zip(ct3.reduced_density_matrices, ct4.reduced_density_matrices, ct3.e_occupations_array):
-        assert np.allclose(rdm3, rdm4, atol=1e-3)
-        assert np.allclose(np.diag(rdm3), e)
 
 
 @pytest.mark.parametrize(
@@ -248,32 +205,3 @@ def test_band_limit_finite_t(
     ct2 = ChargeDiffusionDynamics(mol_list, temperature=low_t, stop_at_edge=False)
     ct2.evolve(evolve_dt, nsteps)
     assert ct1.is_similar(ct2)
-
-
-@pytest.mark.parametrize(
-    "mol_num, j_constant_value, elocalex_value, ph_info, ph_phys_dim, evolve_dt, nsteps",
-    ([3, 1, 3.87e-3, [[1400, 17]], 8, 2, 50],),
-)
-def test_scheme4_finite_t(
-    mol_num, j_constant_value, elocalex_value, ph_info, ph_phys_dim, evolve_dt, nsteps
-):
-    temperature = Quantity(1, "a.u.")
-    ph_list = [
-        Phonon.simple_phonon(
-            Quantity(omega, "cm^{-1}"), Quantity(displacement, "a.u."), ph_phys_dim
-        )
-        for omega, displacement in ph_info
-    ]
-    mol_list = MolList(
-        [Mol(Quantity(elocalex_value, "a.u."), ph_list)] * mol_num,
-        Quantity(j_constant_value, "eV"),
-    )
-    ct1 = ChargeDiffusionDynamics(
-        mol_list.switch_scheme(3), temperature=temperature, stop_at_edge=False
-    )
-    ct1.evolve(evolve_dt, nsteps)
-    ct2 = ChargeDiffusionDynamics(
-        mol_list.switch_scheme(4), temperature=temperature, stop_at_edge=False
-    )
-    ct2.evolve(evolve_dt, nsteps)
-    assert ct1.is_similar(ct2, rtol=1e-2)


### PR DESCRIPTION
- delete redundant code
- remove the warning `krylov.py` because it seems useless. The code is originally borrowed from https://github.com/cmendl/pytenet/blob/master/pytenet/krylov.py which has a fixed number of iterations and the warning is an indicator of early stopping. This is no longer necessary in our adaptive code.
- remove `EmptyMatrixError` as pointed out in #83 
- remove unnecessary tests in `test_dynamics.py`