### PR TITLE
optmize mpo construction

### DIFF
--- a/renormalizer/mps/mpo.py
+++ b/renormalizer/mps/mpo.py
@@ -57,7 +57,7 @@ def symbolic_mpo(table, factor, algo="Hopcroft-Karp"):
     the index of the primary ops {0:"I", 1:"a", 2:r"a^\dagger"}
     
     for example: H = 2.0 * a_1 a_2^dagger   + 3.0 * a_2^\dagger a_3 + 4.0*a_0^\dagger a_3
-    The column names are the site indeces with 0 and 4 imaginary (see the note below)
+    The column names are the site indices with 0 and 4 imaginary (see the note below)
     and the content of the table is the index of primary operators.
                         s0   s1   s2   s3  s4  factor
     a_1 a_2^dagger      0    1    2    0   0   2.0
@@ -82,7 +82,7 @@ def symbolic_mpo(table, factor, algo="Hopcroft-Karp"):
      left side of the above table
      In this case all operators are independent so the content of the matrix is diagonal
     
-    and select the terms and rearange the table 
+    and select the terms and rearrange the table
     The selection rule is to find the minimal number of rows+cols that can eliminate the
     matrix
                       s1   s2 |  s3 s4 factor
@@ -121,6 +121,18 @@ def symbolic_mpo(table, factor, algo="Hopcroft-Karp"):
     
     nsite = len(table[0])
     logger.debug(f"Input operator terms: {len(table)}")
+    # Simplest case. Cut to the chase
+    if len(table) == 1:
+        mpo = []
+        mpoqn = [[0]]
+        for op in table[0]:
+            mpo.append([[[op]]])
+            qn = mpoqn[-1][0] + op.qn
+            mpoqn.append([qn])
+        qntot = qn
+        mpoqn[-1] = [0]
+        qnidx = len(mpo) - 1
+        return mpo, mpoqn, qntot, qnidx
     # translate the symbolic operator table to an easy to manipulate numpy array
     # extract the op symbol, qn, factor to a numpy array
     symbol_table = np.array([[x.symbol for x in ta] for ta in table])

--- a/renormalizer/mps/mpo.py
+++ b/renormalizer/mps/mpo.py
@@ -123,12 +123,16 @@ def symbolic_mpo(table, factor, algo="Hopcroft-Karp"):
     logger.debug(f"Input operator terms: {len(table)}")
     # Simplest case. Cut to the chase
     if len(table) == 1:
-        mpo = []
+        # The first layer: number of sites. The 2nd and 3rd layer: in and out virtual bond
+        # the 4th layer: operator sums
+        mpo: List[List[List[List[[Op]]]]] = []
         mpoqn = [[0]]
         for op in table[0]:
             mpo.append([[[op]]])
             qn = mpoqn[-1][0] + op.qn
             mpoqn.append([qn])
+        old_op = mpo[-1][0][0][0]
+        mpo[-1][0][0][0] = Op(old_op.symbol, old_op.qn, old_op.factor * factor[0])
         qntot = qn
         mpoqn[-1] = [0]
         qnidx = len(mpo) - 1


### PR DESCRIPTION
#100 mentioned a benchmark for `calc_reduced_density_matrix` between `MolList` and `MolList2`. This is my test code:
```
import time
from renormalizer.mps import Mps
from renormalizer.model import MolList, Mol, Phonon, MolList2
from renormalizer.utils import Quantity

mol = Mol(Quantity(0), [Phonon.simplest_phonon(Quantity(1), Quantity(1))])
mol_list = MolList([mol] * 20, Quantity(1), scheme=3)

# test MolList
mps = Mps.random(mol_list, 1, 1)

time1 = time.time()
mps.calc_reduced_density_matrix()
print(time.time() - time1)

# test MolList2
mps = Mps.random(MolList2.MolList_to_MolList2(mol_list), 1, 1)

time1 = time.time()
mps.calc_reduced_density_matrix()
print(time.time() - time1)
```
For `MolList`, the time cost is 2s. For `MolList2`, the time is 20s. The majority of the time is spent on constructing MPOs. 

This PR contains an update to optmize simple MPO construction with `MolList2`. With this update, in the above benchmark `MolList2` also costs 2s.