### PR TITLE
allow auto dump mps if matrices are too large

### DIFF
--- a/renormalizer/cv/tests/test_H_chain.py
+++ b/renormalizer/cv/tests/test_H_chain.py
@@ -19,7 +19,7 @@ def test_H_chain_LDOS():
     spin_norbs = spatial_norbs * 2
     h1e, h2e, nuc = h_qc.read_fcidump(os.path.join(cur_dir,
         "fcidump_lowdin_h4.txt"), spatial_norbs) 
-    
+
     basis, ham_terms = h_qc.qc_model(h1e, h2e)
     
     model = Model(basis, ham_terms)

--- a/renormalizer/model/basis.py
+++ b/renormalizer/model/basis.py
@@ -391,7 +391,7 @@ class BasisSineDVR(BasisSet):
         
         else:
             raise ValueError(f"op_symbol:{op_symbol} is not supported. ")
-        
+
         return mat * op_factor
 
 

--- a/renormalizer/model/model.py
+++ b/renormalizer/model/model.py
@@ -43,7 +43,7 @@ class Model:
         # reusable mpos for the system
         self.mpos = dict()
         # physical bond dimension.
-        self.pbond_list = [bas.nbas for bas in self.basis]
+        self.pbond_list = [local_basis.nbas for local_basis in self.basis]
 
     def check_operator_terms(self, terms: List[Op]):
         """
@@ -67,7 +67,7 @@ class Model:
         dofs = set(self.dofs)
         for term_op in terms:
             if not isinstance(term_op, Op):
-                raise ValueError("Expected Op in terms.")
+                raise ValueError(f"Expected Op in terms. Got {term_op}")
             for name in term_op.dofs:
                 if name not in dofs:
                     raise ValueError(f"{term_op} contains DoF not in the basis.")
@@ -80,9 +80,9 @@ class Model:
     def _enumerate_dof(self, criteria=lambda x: True):
         # enumerate DoFs and filter according to criteria.
         dofs = []
-        for basis in self.basis:
-            if criteria(basis):
-                dofs.extend(basis.dofs)
+        for local_basis in self.basis:
+            if criteria(local_basis):
+                dofs.extend(local_basis.dofs)
         return dofs
 
     @cached_property

--- a/renormalizer/mps/lib.py
+++ b/renormalizer/mps/lib.py
@@ -76,7 +76,9 @@ class Environ:
         assert domain in ["L", "R"]
         assert method in ["Enviro", "System", "Scratch"]
         if mps_conj is None:
-            mps_conj = mps.conj()
+            # provide a dummy value. Creating conjugation of a whole MPS should be avoided when possible
+            # since the operation is actually rather expensive.
+            mps_conj = [None] * len(mps)
 
         if siteidx not in range(len(mps)):
             return self.sentinel

--- a/renormalizer/mps/mp.py
+++ b/renormalizer/mps/mp.py
@@ -4,7 +4,6 @@
 import logging
 import os
 import shutil
-import pickle
 from typing import List, Union
 
 import opt_einsum as oe

--- a/renormalizer/mps/mpo.py
+++ b/renormalizer/mps/mpo.py
@@ -185,8 +185,10 @@ def symbolic_mpo(table, factor, algo="Hopcroft-Karp"):
     # The `Op` class is transformed to a light-weight named tuple
     # for better performance
     OpTuple = namedtuple("OpTuple", ["symbol", "qn", "factor"])
+
     # 0 represents the identity symbol. Identity might not present
     # in `primary_ops` but the algorithm still works.
+
     in_ops = [[OpTuple([0], qn=0, factor=1)]]
 
     for isite in range(nsite):
@@ -345,6 +347,7 @@ def _terms_to_table(model: Model, terms: List[Op], const: float):
 
 
 def _format_symbolic_mpo(symbolic_mpo):
+    # debug tool. Used in the comment of Mpo.__init__
 
     # helper function
     def format_op(op: Op):

--- a/renormalizer/mps/mps.py
+++ b/renormalizer/mps/mps.py
@@ -204,17 +204,17 @@ class Mps(MatrixProduct):
         condition = {model.dof_to_siteidx[key]:value for key, value in
                 condition.items()}
 
-        for isite, bas in enumerate(model.basis):
-            pdim = bas.nbas
+        for isite, local_basis in enumerate(model.basis):
+            pdim = local_basis.nbas
             ms = np.zeros((1, pdim, 1))
             local_state = condition.pop(isite,0)
             if isinstance(local_state, int):
                 ms[0, local_state, 0] = 1.
-                qn = bas.sigmaqn[local_state]
+                qn = local_basis.sigmaqn[local_state]
             else:
                 ms[0, :, 0] = local_state
                 # quantum numbers for all states occupied
-                all_qn = np.array(bas.sigmaqn)[np.nonzero(local_state)]
+                all_qn = np.array(local_basis.sigmaqn)[np.nonzero(local_state)]
                 if all_qn.std() != 0:
                     raise ValueError("Quantum numbers are mixed in the condition.")
                 qn = all_qn[0]
@@ -281,10 +281,10 @@ class Mps(MatrixProduct):
             condition = {model.dof_to_siteidx[key]:value for key, value in
                     condition.items()}
 
-        for isite, basis in enumerate(model.basis):
-            pdim = basis.nbas
+        for isite, local_basis in enumerate(model.basis):
+            pdim = local_basis.nbas
             ms = np.zeros((1, pdim, 1))
-            if basis.is_phonon:
+            if local_basis.is_phonon:
                 if max_entangled:
                     if normalize:
                         ms[0, :, 0] = 1.0 / np.sqrt(pdim)
@@ -294,27 +294,27 @@ class Mps(MatrixProduct):
                     ms[0, 0, 0] = 1.0
                 mps[isite] = ms
 
-            elif basis.is_electron or basis.is_spin:
+            elif local_basis.is_electron or local_basis.is_spin:
 
-                if isinstance(basis, ba.BasisSimpleElectron):
+                if isinstance(local_basis, ba.BasisSimpleElectron):
                     # simple electron site
                     ms[0,0,0] = 1.
-                elif isinstance(basis, ba.BasisMultiElectron):
+                elif isinstance(local_basis, ba.BasisMultiElectron):
                     assert condition is not None
                     local_state = condition.pop(isite)
                     if isinstance(local_state, int):
                         ms[0, local_state, 0] = 1.
-                        qn = basis.sigmaqn[local_state]
+                        qn = local_basis.sigmaqn[local_state]
                     else:
                         ms[0, :, 0] = local_state
-                        qn = basis.sigmaqn[np.nonzero(local_state)]
+                        qn = local_basis.sigmaqn[np.nonzero(local_state)]
                     assert np.allclose(qn, 0)
                     if max_entangled and normalize:
                         ms /= np.linalg.norm(ms)
 
-                elif isinstance(basis, ba.BasisMultiElectronVac):
+                elif isinstance(local_basis, ba.BasisMultiElectronVac):
                         ms[0,0,0] = 1.
-                elif isinstance(basis, ba.BasisHalfSpin):
+                elif isinstance(local_basis, ba.BasisHalfSpin):
                     if max_entangled:
                         if normalize:
                             ms[0,:,0] = 1. / np.sqrt(2.)

--- a/renormalizer/mps/mps.py
+++ b/renormalizer/mps/mps.py
@@ -195,7 +195,7 @@ class Mps(MatrixProduct):
         mps.model = model
         mps.build_empty_mp(model.nsite)
         qn_single = [[],] * model.nsite
-        
+
         # check that the condition is not duplicated
         # each site has at most 1 single key to assign the occupation  
         index = [model.dof_to_siteidx[key] for key in condition.keys()]
@@ -281,10 +281,10 @@ class Mps(MatrixProduct):
             condition = {model.dof_to_siteidx[key]:value for key, value in
                     condition.items()}
 
-        for isite, bas in enumerate(model.basis):
-            pdim = bas.nbas
+        for isite, basis in enumerate(model.basis):
+            pdim = basis.nbas
             ms = np.zeros((1, pdim, 1))
-            if bas.is_phonon:
+            if basis.is_phonon:
                 if max_entangled:
                     if normalize:
                         ms[0, :, 0] = 1.0 / np.sqrt(pdim)
@@ -294,27 +294,27 @@ class Mps(MatrixProduct):
                     ms[0, 0, 0] = 1.0
                 mps[isite] = ms
 
-            elif bas.is_electron or bas.is_spin:
+            elif basis.is_electron or basis.is_spin:
 
-                if isinstance(bas, ba.BasisSimpleElectron):
+                if isinstance(basis, ba.BasisSimpleElectron):
                     # simple electron site
                     ms[0,0,0] = 1.
-                elif isinstance(bas, ba.BasisMultiElectron):
+                elif isinstance(basis, ba.BasisMultiElectron):
                     assert condition is not None
                     local_state = condition.pop(isite)
                     if isinstance(local_state, int):
                         ms[0, local_state, 0] = 1.
-                        qn = bas.sigmaqn[local_state]
+                        qn = basis.sigmaqn[local_state]
                     else:
                         ms[0, :, 0] = local_state
-                        qn = bas.sigmaqn[np.nonzero(local_state)]
+                        qn = basis.sigmaqn[np.nonzero(local_state)]
                     assert np.allclose(qn, 0)
                     if max_entangled and normalize:
                         ms /= np.linalg.norm(ms)
 
-                elif isinstance(bas, ba.BasisMultiElectronVac):
+                elif isinstance(basis, ba.BasisMultiElectronVac):
                         ms[0,0,0] = 1.
-                elif isinstance(bas, ba.BasisHalfSpin):
+                elif isinstance(basis, ba.BasisHalfSpin):
                     if max_entangled:
                         if normalize:
                             ms[0,:,0] = 1. / np.sqrt(2.)
@@ -791,9 +791,12 @@ class Mps(MatrixProduct):
                     np.ones([1, 1], dtype=mps.dtype),
                 ]
                 for imps in range(mps.site_num):
+                    mps_conj = mps.conj()
                     S_L_list.append(
-                        transferMat(mps, mps.conj(), "L", imps, S_L_list[imps])
+                        transferMat(mps, mps_conj, "L", imps, S_L_list[imps])
                     )
+                    del mps_conj
+
 
                 S_L_inv_list = []
                 for imps in range(mps.site_num + 1):
@@ -988,9 +991,11 @@ class Mps(MatrixProduct):
                 # construct the S_L list (type: Matrix) and S_L_inv list (type: xp.array)
                 # len: mps.site_num+1
                 S_L_list = [np.ones([1, 1], dtype=mps.dtype),]
+                environ_mps_conj = environ_mps.conj()
                 for imps in range(mps.site_num):
-                    S_L_list.append(transferMat(environ_mps, environ_mps.conj(), "L", imps,
+                    S_L_list.append(transferMat(environ_mps, environ_mps_conj, "L", imps,
                         S_L_list[imps]))
+                del environ_mps_conj
 
                 S_L_inv_list = []
                 for imps in range(mps.site_num+1):
@@ -1174,7 +1179,7 @@ class Mps(MatrixProduct):
                     mps.qnidx = imps-1
 
                     r_array = environ.GetLR(
-                        "R", imps, mps, mpo, itensor=r_array, method="System"
+                        "R", imps, mps, mpo, itensor=r_array, method="System", mps_conj=mps_conj
                     )
 
                     # reverse update u site
@@ -1211,7 +1216,7 @@ class Mps(MatrixProduct):
                     mps.qnidx = imps+1
 
                     l_array = environ.GetLR(
-                        "L", imps, mps, mpo, itensor=l_array, method="System"
+                        "L", imps, mps, mpo, itensor=l_array, method="System", mps_conj=mps_conj
                     )
 
                     # reverse update svt site

--- a/renormalizer/mps/tests/test_evolve.py
+++ b/renormalizer/mps/tests/test_evolve.py
@@ -50,6 +50,8 @@ def check_result(mps, mpo, time_step, final_time, atol=1e-4):
     # used for debugging
     mcd = np.abs(expectations - qutip_expectations[:qutip_end:qutip_interval]).mean()
     assert mcd < atol
+    # return mps for possible further analysis
+    return mps
 
 # useful debugging code
 # from matplotlib import pyplot as plt
@@ -113,3 +115,14 @@ def compare():
     print(mps.bond_dims)
     print(all_values)
 
+
+@pytest.mark.parametrize("method, dt", ([EvolveMethod.prop_and_compress, 0.2], [EvolveMethod.tdvp_ps, 0.4]))
+def test_dump(method, dt):
+    mps = init_mps.copy()
+    mps.evolve_config = EvolveConfig(method)
+    # dump all matrices
+    mps.compress_config = CompressConfig(CompressCriteria.fixed, dump_matrix_size=1)
+    evolved_mps = check_result(mps, mpo, dt, 5)
+    # check all matrices are actually dumped
+    for mt in evolved_mps._mp:
+        assert isinstance(mt, str)

--- a/renormalizer/utils/configs.py
+++ b/renormalizer/utils/configs.py
@@ -58,6 +58,18 @@ class CompressConfig:
 
         - ``1site``:  optimize one site at a time during sweep.
         - ``2site``:  optimize two site at a time during sweep.
+
+        Note
+        ----
+        It is recommended to use the 2site algorithm in variational optimization,
+        though 1site algorithm is much cheaper. The reason is that 1site algorithm
+        is easy to stuck into local mimima while 2site algorithm is more robust. For
+        complicated Hamiltonian, the problem is severer.  The renormalized basis
+        selection rule used here to partly solve the local minimal problem is
+        according to Chan. J.  Chem. Phys. 2004, 120, 3172. For efficiency, you
+        could use 2site algorithm for several sweeps and then switch to 1site
+        algorithm to converge the final mps.
+
     vprocedure : list, optional
         The procedure to do variational compression.
         The Default is
@@ -74,22 +86,26 @@ class CompressConfig:
     
     vrtol : float, optional
         The threshold of convergence in variational compression. Default is
-        :math:`10^-5`.
+        :math:`10^{-5}`.
     vguess_m : tuple(int), optional
         The bond dimension of ``compressed_mpo`` and ``compressed_mps`` to construct the initial guess 
         ``compressed_mpo @ compressed_mps`` in `MatrixProduct.variational_compress`.
         The default is (5,5).
-    
-    Note
-    ----
-    It is recommended to use the 2site algorithm in variational optimization,
-    though 1site algorithm is much cheaper. The reason is that 1site algorithm
-    is easy to stuck into local mimima while 2site algorithm is more robust. For
-    complicated Hamiltonian, the problem is severer.  The renormalized basis
-    selection rule used here to partly solve the local minimal problem is
-    according to Chan. J.  Chem. Phys. 2004, 120, 3172. For efficiency, you
-    could use 2site algorithm for several sweeps and then switch to 1site
-    algorithm to converge the final mps.
+    dump_matrix_size : int or float, optional
+        The total bytes threshold for dumping matrix into disks. Every local site matrix in the MPS
+        with a size larger than the specified size will be moved from memory to the disk at ``dump_matrix_dir``.
+        The matrix will be moved back to memory upon access.
+        The dumped matrices on the disks will be removed once the MPS is garbage-collected.
+
+        Note
+        ----
+        If ``dump_matrix_size`` is set and the program exits abnormally, it is possible that the dumped matrices
+        are not deleted automatically. A common case when this can happen is that the program is killed by a signal.
+        In such cases it is recommended to check and clean ``dump_matrix_dir`` manually after the exit of the program
+        since the dumped matrices may take a lot of disk space.
+
+    dump_matrix_dir : str, optional
+        The directory to dump matrix when matrix is larger than ``dump_matrix_size``.
 
     See Also
     --------
@@ -108,6 +124,8 @@ class CompressConfig:
         vprocedure = None,
         vrtol = 1e-5,
         vguess_m = (5,5),
+        dump_matrix_size = np.inf,
+        dump_matrix_dir = "./",
     ):
         # two sets of criteria here: threshold and max_bonddimension
         # `criteria` is to determine which to use
@@ -135,6 +153,9 @@ class CompressConfig:
         self.vprocedure = vprocedure
         self.vrtol = vrtol
         self.vguess_m = vguess_m
+
+        self.dump_matrix_size = dump_matrix_size
+        self.dump_matrix_dir = dump_matrix_dir
 
     @property
     def threshold(self):

--- a/renormalizer/utils/configs.py
+++ b/renormalizer/utils/configs.py
@@ -35,7 +35,7 @@ class CompressCriteria(Enum):
 
 
 class CompressConfig:
-    """MPS Compress Configuration.
+    """MPS/MPO Compress Configuration.
 
     Parameters
     ----------
@@ -63,7 +63,7 @@ class CompressConfig:
         ----
         It is recommended to use the 2site algorithm in variational optimization,
         though 1site algorithm is much cheaper. The reason is that 1site algorithm
-        is easy to stuck into local mimima while 2site algorithm is more robust. For
+        is easy to stuck into local minima while 2site algorithm is more robust. For
         complicated Hamiltonian, the problem is severer.  The renormalized basis
         selection rule used here to partly solve the local minimal problem is
         according to Chan. J.  Chem. Phys. 2004, 120, 3172. For efficiency, you
@@ -92,16 +92,16 @@ class CompressConfig:
         ``compressed_mpo @ compressed_mps`` in `MatrixProduct.variational_compress`.
         The default is (5,5).
     dump_matrix_size : int or float, optional
-        The total bytes threshold for dumping matrix into disks. Every local site matrix in the MPS
+        The total bytes threshold for dumping matrix into disks. Every local site matrix in the MPS/MPO
         with a size larger than the specified size will be moved from memory to the disk at ``dump_matrix_dir``.
         The matrix will be moved back to memory upon access.
-        The dumped matrices on the disks will be removed once the MPS is garbage-collected.
+        The dumped matrices on the disks will be removed once the MPS/MPO is garbage-collected.
 
         Note
         ----
         If ``dump_matrix_size`` is set and the program exits abnormally, it is possible that the dumped matrices
         are not deleted automatically. A common case when this can happen is that the program is killed by a signal.
-        In such cases it is recommended to check and clean ``dump_matrix_dir`` manually after the exit of the program
+        In such cases it is recommended to check and clean ``dump_matrix_dir`` after the exit of the program
         since the dumped matrices may take a lot of disk space.
 
     dump_matrix_dir : str, optional


### PR DESCRIPTION
This PR adds new options to the `CompressConfig`. The user can choose to dump large matrices to a specified directory in order to save memory.  After the argument is set the save/load of the matrices is transparent to the user. 

The mechanism is that when a numpy array is converted to `Matrix` in `MatrixProduct` the size of the array is checked and
if it is larger than a specified threshold, it is saved to disk, and a `str` indicating the filename of the array is stored in `_mp` of `MatrixProduct`.

The dumped matrices are deleted when `MatrixProduct` is garbage collected. However, if the program exits <del>normally</del>abnormally, e.g. killed by someone, the matrices might not be properly deleted. Theoretically, there is no perfect solution for this. The point of `kill` is to stop the program no matter what.