### PR TITLE
fix mps.load bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Renormalizer is a python package based on tensor network states for electron-phonon quantum dynamics.
 
-[![Build Status](https://travis-ci.org/shuaigroup/Renormalizer.svg?branch=master)](https://travis-ci.org/shuaigroup/Renormalizer)
+[![Build Status](https://travis-ci.com/shuaigroup/Renormalizer.svg?branch=master)](https://travis-ci.com/shuaigroup/Renormalizer)
 ## Installation
 Installation guide can be found in the [project wiki](https://github.com/shuaigroup/Renormalizer/wiki/Installation-guide).
 

--- a/renormalizer/mps/mps.py
+++ b/renormalizer/mps/mps.py
@@ -357,7 +357,7 @@ class Mps(MatrixProduct):
             mp.coeff = npload["tdh_wfns"][-1]
         elif version == "0.3":
             mp.to_right = bool(npload["to_right"])
-            mp.coeff = npload["coeff"].tolist()
+            mp.coeff = npload["coeff"].item(0)
         else:
             raise ValueError(f"Unknown dump version: {version}")
         return mp

--- a/renormalizer/mps/mps.py
+++ b/renormalizer/mps/mps.py
@@ -357,7 +357,7 @@ class Mps(MatrixProduct):
             mp.coeff = npload["tdh_wfns"][-1]
         elif version == "0.3":
             mp.to_right = bool(npload["to_right"])
-            mp.coeff = npload["coeff"]
+            mp.coeff = npload["coeff"].tolist()
         else:
             raise ValueError(f"Unknown dump version: {version}")
         return mp


### PR DESCRIPTION
After TDH hybrid algorithm is removed (#61 ), the `coeff` for `mps` is changed from type `list` to type `complex` or `float`.
However, when an `Mps` (or `MpDm`) is loaded from an `npz` file, the datatype for `coeff` is cast to a NumPy array of size 1 * 1. This is the default behavior for the `npz` archive. 
This bug could lead to severe problems because the code logic is based on the assumption that `coeff` is a number instead of an array.  For example, in `Mps.metacopy`  it is written:
```
new.coeff = self.coeff
```
and then `new` and `self` would share the same `coeff` array.

A quick fix is to use the [`tolist` function of NumPy](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.tolist.html)