### PR TITLE
Add one-particle spectral function for charge transport problems

### DIFF
--- a/doc/source/ct.rst
+++ b/doc/source/ct.rst
@@ -12,4 +12,8 @@ Charge diffusion dynamics simulation
    :members:
 
 
+One-Particle Spectral Function
+==============================
+.. automodule:: renormalizer.transport.spectral_function
+   :members:
 

--- a/doc/source/model.rst
+++ b/doc/source/model.rst
@@ -23,6 +23,12 @@ The Model classes
     :members:
     :inherited-members:
 
+
+.. autoclass:: renormalizer.model.TI1DModel
+    :members:
+    :inherited-members:
+
+
 Basis Functions
 ===============
 

--- a/doc/source/model.rst
+++ b/doc/source/model.rst
@@ -1,8 +1,11 @@
 Model
 *************************************
 
-Use the class :class:`~renormalizer.model.Model`, :class:`~renormalizer.model.HolsteinModel`,
-or :class:`~renormalizer.model.SpinBosonModel` to define the calculated system.
+Use the :class:`~renormalizer.model.Model` classes to define the system to be calculated.
+We provide the Holstein model :class:`renormalizer.model.HolsteinModel`
+and the spin-boson model :class:`~renormalizer.model.SpinBosonModel` out of box, yet any arbitrary model
+with sum-of-product Hamiltonian
+can be constructed by using the most general :class:`~renormalizer.model.Model` class.
 These classes require :class:`~renormalizer.model.basis.BasisSet` and :class:`~renormalizer.model.Op`
 as input.
 

--- a/renormalizer/model/__init__.py
+++ b/renormalizer/model/__init__.py
@@ -4,4 +4,4 @@
 from renormalizer.model.phonon import Phonon
 from renormalizer.model.mol import Mol
 from renormalizer.model.op import Op
-from renormalizer.model.model import Model, load_from_dict, HolsteinModel, SpinBosonModel
+from renormalizer.model.model import Model, load_from_dict, HolsteinModel, SpinBosonModel, TI1DModel

--- a/renormalizer/model/basis.py
+++ b/renormalizer/model/basis.py
@@ -80,6 +80,23 @@ class BasisSet:
             return (self.dof,)
 
 
+    def copy(self, new_dof):
+        """
+        Return a copy of the basis set with new DoF name specified in the argument.
+
+        Parameters
+        ----------
+        new_dof:
+            New DoF name.
+
+        Returns
+        -------
+        new_basis : Basis
+            A copy of the basis with new DoF name.
+        """
+        raise NotImplementedError
+
+
 class BasisSHO(BasisSet):
     """
     simple harmonic oscillator basis set
@@ -299,6 +316,12 @@ class BasisSHO(BasisSet):
         self._recurssion_flag -= 1
         return mat * op_factor
 
+    def copy(self, new_dof):
+        return self.__class__(new_dof, omega=self.omega,
+                              nbas=self.nbas, x0=self.x0,
+                              dvr=self.dvr, general_xp_power=self.general_xp_power)
+
+
 class BasisSineDVR(BasisSet):
     r"""
     Sine DVR basis (particle-in-a-box) for vibrational, angular, and
@@ -394,6 +417,9 @@ class BasisSineDVR(BasisSet):
 
         return mat * op_factor
 
+    def copy(self, new_dof):
+        return self.__class__(new_dof, self.nbas, xi=self.xi, xf=self.xf)
+
 
 class BasisMultiElectron(BasisSet):
     r"""
@@ -446,6 +472,9 @@ class BasisMultiElectron(BasisSet):
             raise ValueError(f"op_symbol:{op_symbol} is not supported")
 
         return mat * op_factor
+
+    def copy(self, new_dof):
+        return self.__class__(new_dof, self.sigmaqn)
 
 
 class BasisMultiElectronVac(BasisSet):
@@ -508,6 +537,8 @@ class BasisMultiElectronVac(BasisSet):
 
         return mat * op_factor
 
+    def copy(self, new_dof):
+        return self.__class__(new_dof)
 
 class BasisSimpleElectron(BasisSet):
 
@@ -544,6 +575,9 @@ class BasisSimpleElectron(BasisSet):
             raise ValueError(f"op_symbol:{op_symbol} is not supported")
         
         return mat * op_factor
+
+    def copy(self, new_dof):
+        return self.__class__(new_dof)
 
 
 class BasisHalfSpin(BasisSet):
@@ -595,6 +629,9 @@ class BasisHalfSpin(BasisSet):
                 mat = mat @ self.op_mat(o)
 
         return mat * op_factor
+
+    def copy(self, new_dof):
+        return self.__class__(new_dof, self.sigmaqn)
 
 
 def x_power_k(k, m, n):

--- a/renormalizer/model/model.py
+++ b/renormalizer/model/model.py
@@ -399,11 +399,11 @@ class TI1DModel(Model):
     The Hamiltonian should take the form:
 
     .. math::
-        \hat H = \sum_i(\hat h_i + \sum_j \hat h_{i, i+j})
+        \hat H = \sum_i(\hat h_i + \sum_j \hat h_{i,j})
 
     where :math:`\hat h_i` is the local Hamiltonian acting on one single unit cell
-    and :math:`\hat h_{i, i+j}` represents the interaction between the :math:`i` th cell
-    and the :math:`i+j` th cell.
+    and :math:`\hat h_{i,j}` represents the :math:`j` th interaction between the :math:`i` th cell
+    and other unit cells.
 
     Yet doesn't support setting transition dipoles.
 
@@ -420,14 +420,17 @@ class TI1DModel(Model):
         Terms of the system local Hamiltonian :math:`\hat h_i` in sum-of-product form.
         DoF names should be consistent with the ``basis`` argument.
     nonlocal_ham_terms : :class:`list` of :class:`~renormalizer.model.Op`
-        Terms of system nonlocal Hamiltonian :math:`\hat h_{i, i+j}`.
+        Terms of system nonlocal Hamiltonian :math:`\hat h_{i,j}`.
         To indicate the IDs of the unit cells that are involved in the nonlocal interaction,
         the DoF name in ``basis`` should be transformed to a two-element-tuple, in which
-        the first element is an integer :math:`j`, and the second element is the original DoF name.
+        the first element is an integer indicating its distance from :math:`i`,
+        and the second element is the original DoF name.
         For example, if one unit cell contains one electron DoF with name ``e``,
         a nearest neighbour hopping interaction
         should take the form ``Op(r"a^\dagger a", [(0, "e"), (1, "e")])``
         (with its Hermite conjugation being another term).
+        The definition is not unique in that ``Op(r"a^\dagger a", [(1, "e"), (2, "e")])``
+        produces equivalent output.
     ncell : int
         Number of unit cells in the system.
     """
@@ -459,7 +462,6 @@ class TI1DModel(Model):
                 new_op = Op(old_op.symbol, new_dofs, old_op.factor, old_op.qn_list)
                 full_ham_terms.append(new_op)
         super().__init__(full_basis, full_ham_terms)
-
 
 
 def construct_j_matrix(mol_num, j_constant, periodic):

--- a/renormalizer/mps/mps.py
+++ b/renormalizer/mps/mps.py
@@ -454,11 +454,11 @@ class Mps(MatrixProduct):
         # This is time and memory consuming
         # return self_conj.dot(mpo.apply(self)).real
 
-    def expectations(self, mpos, opt=True) -> np.ndarray:
+    def expectations(self, mpos, self_conj=None, opt=True) -> np.ndarray:
 
         if not opt:
             # the naive way, slow and time consuming. Yet predictable and reliable
-            return np.array([self.expectation(mpo) for mpo in mpos])
+            return np.array([self.expectation(mpo, self_conj) for mpo in mpos])
 
         # optimized way, cache for intermediates
         # hash is used as indeces of the matrices.
@@ -479,7 +479,8 @@ class Mps(MatrixProduct):
                 mpo_hash.append(m_hash)
             mpos_hash.append(mpo_hash)
 
-        self_conj = self._expectation_conj()
+        if self_conj is None:
+            self_conj = self._expectation_conj()
         l_environ_dict = _construct_freq_environ(mpos_hash, hash_to_obj, self, "L", self_conj)
         r_environ_dict = _construct_freq_environ(mpos_hash, hash_to_obj, self, "R", self_conj)
         results = []

--- a/renormalizer/mps/tests/test_mps.py
+++ b/renormalizer/mps/tests/test_mps.py
@@ -35,6 +35,13 @@ def test_expectations(mpos):
 
     assert np.allclose(e1, e2)
 
+    random2 = Mps.random(parameter.holstein_model, 1, 20)
+
+    e1 = random.expectations(mpos, random2)
+    e2 = random.expectations(mpos, random2, opt=False)
+
+    assert np.allclose(e1, e2)
+
 
 def check_reduced_density_matrix(basis):
     model = Model(basis, [])

--- a/renormalizer/mps/thermalprop.py
+++ b/renormalizer/mps/thermalprop.py
@@ -45,6 +45,7 @@ class ThermalProp(TdMpsJob):
         auto_expand: bool = True,
     ):
         self.init_mpdm: MpDm = init_mpdm.canonicalise()
+        # todo: remove h_mpo. construct from init_mpdm.model
         self.h_mpo = h_mpo
         self.exact = exact
         assert space in ["GS", "EX"]

--- a/renormalizer/transport/spectral_function.py
+++ b/renormalizer/transport/spectral_function.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+
+import logging
+
+from renormalizer.mps.backend import np
+from renormalizer.mps import Mpo, Mps
+from renormalizer.utils import TdMpsJob, Quantity, EvolveConfig, CompressConfig
+from renormalizer.model import Model, TI1DModel
+
+
+logger = logging.getLogger(__name__)
+
+
+
+class SpectralFunctionZT(TdMpsJob):
+    r"""
+    Calculate one-particle retarded Green's function at zero temperature for translational invariant one-dimensional model:
+
+    .. math::
+        iG_{ij}(t) = \langle 0 |c_i(t) c^\dagger_j | 0 \rangle
+
+    The value of the array is stored with key ``"G array"`` in the dumped output file.
+    Because of the translational invariance, there are only two dimension in this array.
+    The first dimension is :math:`t` and the second dimension is :math:`|i-j|`.
+    In k-space, :math:`iG_{ij}` is transformed to:
+
+    .. math::
+        iG_k(t) = \langle 0 |c_k(t) c^\dagger_k | 0 \rangle
+
+    and this array is saved with key ``"Gk array"`` in the dumped output file.
+    Fourier transformation of :math:`G_k(t)` results in the spectral function:
+
+    .. math::
+        A(k, \omega) = -\frac{1}{\pi} \int_0^\infty dt e^{i \omega t} G_k(t)
+
+    However, this value is not calculated directly in this class, since usually an broadening to :math:`G_k(t)`
+    is required and an optimal range of :math:`\omega` usually can not be determined without additional knowledge.
+
+    For finite temperature spectral function, it is recommended to use
+    thermal field dynamics and transform the Hamiltonian.
+    An example is included in the test case.
+    See J. Chem.Phys.145, 224101 (2016) and
+    Phys. Rev. Lett.123, 090402 (2019) for details.
+
+    Parameters
+    ==========
+    model : :class:`~renormalizer.model.TI1DModel`
+        system information. In principle should use :class:`~renormalizer.model.TI1DModel`.
+        Using custom :class:`~renormalizer.model.Model` is possible however
+        in this case the user should be responsible to ensure the translational invariance.
+    compress_config : :class:`~renormalizer.utils.configs.CompressConfig`
+        config when compressing MPS.
+    evolve_config : :class:`~renormalizer.utils.configs.EvolveConfig`
+        config when carrying out real time propagation.
+    dump_dir : str
+        the directory for logging and numerical result output.
+    job_name : str
+        the name of the calculation job which determines the file name of the logging and numerical result output.
+    """
+
+    def __init__(
+            self,
+            model: TI1DModel,
+            compress_config: CompressConfig = None,
+            evolve_config: EvolveConfig = None,
+            dump_dir: str = None,
+            job_name: str=None,
+    ):
+        self.model: TI1DModel = model
+        self.compress_config = compress_config
+        if self.compress_config is None:
+            self.compress_config = CompressConfig()
+        # electron-addition Green's function at different $t$ assuming translational invariance
+        self._G_array = []
+        self.e_occupations_array = []
+        self.temperature = Quantity(0)
+        super().__init__(evolve_config, False, dump_dir, job_name)
+
+    @property
+    def G_array(self):
+        """
+        :math:`G_{ij}(t)` as a two dimensional array.
+        The first dimension is :math:`t` and the second dimension is :math:`|i-j|`.
+
+        Returns
+        =======
+        G_array : np.ndarray
+            The Green's function array
+        """
+        return np.array(self._G_array)
+
+    def init_mps(self):
+        creation_oper = Mpo.onsite(self.model, r"a^\dagger", dof_set={self.model.e_dofs[0]})
+        gs = Mps.ground_state(self.model, False)
+        self.h_mpo = Mpo(self.model, offset=Quantity(gs.expectation(Mpo(self.model))))
+        a_ket = creation_oper.apply(gs, canonicalise=True)
+        a_ket.compress_config = self.compress_config
+        a_ket.evolve_config = self.evolve_config
+        a_ket.canonical_normalize()
+        if self.evolve_config.is_tdvp:
+            a_ket = a_ket.expand_bond_dimension(self.h_mpo)
+        return (gs, a_ket)
+
+    def process_mps(self, mps):
+        key = "a"
+        if key not in self.model.mpos:
+            a_opers = [Mpo.onsite(self.model, "a", dof_set={dof}) for dof in self.model.e_dofs]
+            self.model.mpos[key] = a_opers
+        else:
+            a_opers = self.model.mpos[key]
+
+        a_bra_mpo, a_ket_mpo = mps
+        G = a_ket_mpo.expectations(a_opers, a_bra_mpo.conj()) / 1j
+        self._G_array.append(G)
+        self.e_occupations_array.append(a_ket_mpo.e_occupations)
+
+    def evolve_single_step(self, evolve_dt):
+        prev_bra_mpdm, prev_ket_mpdm = self.latest_mps
+        latest_ket_mpdm = prev_ket_mpdm.evolve(self.h_mpo, evolve_dt)
+        return (prev_bra_mpdm, latest_ket_mpdm)
+
+    def get_dump_dict(self):
+        dump_dict = dict()
+        dump_dict['temperature'] = self.temperature.as_au()
+        dump_dict['time series'] = self.evolve_times
+        dump_dict["G array"] = self.G_array
+        ne = self.model.n_edofs
+        ka = np.linspace(0, np.pi, ne // 2 + 1).reshape(1, 1, -1)
+        ijdiff = np.arange(ne).reshape(1, -1, 1)
+        # Green's function in k space
+        dump_dict["Gk array"] = np.sum(self.G_array.reshape(-1, ne, 1) * np.exp(1j * ka * ijdiff), axis=1)
+        dump_dict["electron occupations array"] = self.e_occupations_array
+        return dump_dict

--- a/renormalizer/transport/tests/test_spectral_function.py
+++ b/renormalizer/transport/tests/test_spectral_function.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+
+import numpy as np
+
+import qutip
+import pytest
+
+from renormalizer.model import Op, TI1DModel
+from renormalizer.model.basis import BasisSimpleElectron, BasisSHO
+from renormalizer.transport.spectral_function import SpectralFunctionZT
+from renormalizer.utils import Quantity
+from renormalizer.utils.configs import CompressConfig, EvolveMethod, EvolveConfig, CompressCriteria
+from renormalizer.utils.qutip_utils import get_clist, get_blist, get_holstein_hamiltonian
+
+
+
+def test_spectral_function_bogoliubov():
+    # nlevels must be large enough compared with T/omega for the algorithm (Bogoliubov transformation) to work
+    # For fast qutip calculation maximum nlevels is 4
+    # so temperature has to be low
+    temperature = Quantity(0.2)
+    nsites = 3
+    omega = 1
+
+    nlevels = 4
+    g = 1
+
+    ti_basis = [
+        BasisSimpleElectron("e"),
+        BasisSHO("ph0", omega, nlevels),
+        BasisSHO("ph1", omega, nlevels)
+    ]
+    theta = np.arctanh(np.exp(-temperature.to_beta() * omega / 2))
+    ti_local_terms = [
+        Op(r"a^\dagger a", "e", g ** 2 * omega),
+        Op(r"b^\dagger b", "ph0", omega),
+        Op(r"b^\dagger b", "ph1", -omega),
+        - g * np.cosh(theta) * omega * Op(r"a^\dagger a", "e") * Op(r"b^\dagger + b", "ph0"),
+        - g * np.sinh(theta) * omega * Op(r"a^\dagger a", "e") * Op(r"b^\dagger + b", "ph1")
+    ]
+    ti_nonlocal_terms = [
+        Op(r"a^\dagger a", [(0, "e"), (1, "e")]),
+        Op(r"a^\dagger a", [(1, "e"), (0, "e")]),
+    ]
+    model = TI1DModel(ti_basis, ti_local_terms, ti_nonlocal_terms, nsites)
+
+    compress_config = CompressConfig(CompressCriteria.fixed, max_bonddim=24)
+    evolve_config = EvolveConfig(EvolveMethod.tdvp_ps)
+    sf = SpectralFunctionZT(model, compress_config=compress_config, evolve_config=evolve_config)
+    sf.evolve(nsteps=5, evolve_time=2.5)
+
+    qutip_res = get_qutip_holstein_sf(nsites, 1, nlevels, omega, g, temperature, sf.evolve_times_array)
+    assert np.allclose(sf.G_array[:, 1], qutip_res, rtol=1e-2)
+
+
+def get_qutip_holstein_sf(nsites, J, ph_levels, omega, g, temperature, time_series):
+    if temperature == 0:
+        beta = 1e100
+    else:
+        beta = temperature.to_beta()
+    clist = get_clist(nsites, ph_levels)
+    blist = get_blist(nsites, ph_levels)
+
+    H = get_holstein_hamiltonian(nsites, J, omega, g, clist, blist, True)
+    init_state_list = []
+    for i in range(nsites):
+        egs = qutip.basis(2, 0)
+        init_state_list.append(egs * egs.dag())
+        b = qutip.destroy(ph_levels)
+        init_state_list.append((-beta * (omega * b.dag() * b)).expm().unit())
+    init_state = qutip.tensor(init_state_list)
+
+    return qutip.correlation(H, init_state, [0], time_series, [], clist[1], clist[0].dag())[0] / 1j

--- a/renormalizer/transport/tests/test_spectral_function.py
+++ b/renormalizer/transport/tests/test_spectral_function.py
@@ -13,7 +13,6 @@ from renormalizer.utils.configs import CompressConfig, EvolveMethod, EvolveConfi
 from renormalizer.utils.qutip_utils import get_clist, get_blist, get_holstein_hamiltonian
 
 
-
 def test_spectral_function_bogoliubov():
     # nlevels must be large enough compared with T/omega for the algorithm (Bogoliubov transformation) to work
     # For fast qutip calculation maximum nlevels is 4

--- a/renormalizer/utils/qutip_utils.py
+++ b/renormalizer/utils/qutip_utils.py
@@ -39,16 +39,18 @@ def get_blist(nsites, ph_levels):
     return blist
 
 
-def get_holstein_hamiltonian(nsites, J, omega, g, clist, blist):
+def get_holstein_hamiltonian(nsites, J, omega, g, clist, blist, periodic=False):
     lam = g ** 2 * omega
     terms = []
     for i in range(nsites):
         terms.append(lam * clist[i].dag() * clist[i])
         terms.append(omega * blist[i].dag() * blist[i])
         terms.append(-omega * g * clist[i].dag() * clist[i] * (blist[i].dag() + blist[i]))
-    for i in range(nsites - 1):
-        terms.append(J * clist[i].dag() * clist[i + 1])
-        terms.append(J * clist[i] * clist[i + 1].dag())
+    hop_limit = nsites if periodic else nsites -1
+    for i in range(hop_limit):
+        next_i = (i+1) % nsites
+        terms.append(J * clist[i].dag() * clist[next_i])
+        terms.append(J * clist[i] * clist[next_i].dag())
 
     return sum(terms)
 

--- a/renormalizer/utils/tdmps.py
+++ b/renormalizer/utils/tdmps.py
@@ -46,6 +46,15 @@ class TdMpsJob(object):
         raise NotImplementedError
 
     def process_mps(self, mps):
+        """
+        Process the newly evolved the mps. Primarily for the calculation of properties.
+        Note that currently ``self.latest_mps`` has not been updated.
+
+        Parameters
+        ==========
+        mps :
+             The evolved new mps of the time step.
+        """
         raise NotImplementedError
 
     def evolve(self, evolve_dt=None, nsteps=None, evolve_time=None):


### PR DESCRIPTION
- A new class `SpectralFunctionZT` for the one-particle spectral function at zero temperature. The finite temperature effect can be taken into account using the thermal field dynamics algorithm mentioned in the document and exemplified in the test case.
- The algorithm is only valid for a translational invariant one-dimensional system. To restrict its application and simplify model definition for the very common case, a new `Model` for translational invariant one dimensional system `TI1DModel` is added.
- The `todo` for removing `h_mpo` argument in `ThermalProp`  is based on the fact that the `h_mpo` for every step of time evolution is actually constructed from the model of the `h_mpo`:
https://github.com/shuaigroup/Renormalizer/blob/9aeaad9190b11c55898fbbe51c025b9a92471044/renormalizer/mps/thermalprop.py#L100-L102
However the constructed `h_mpo` is not necessarily the same as the `h_mpo` in the argument. Since in `Mpo.__init__` we actually allow construct MPO apart from the Hamiltonian. I've got a plan to improve the API and I think I'm going to open an issue for it as it involves a drastic change of a commonly used API.