### PR TITLE
Update on ThermalProp interface, FT-CT interface and optimize SVD

### DIFF
--- a/doc/source/ct.rst
+++ b/doc/source/ct.rst
@@ -1,12 +1,12 @@
 Charge Transport
 *************************************
 
-Obtain mobility by Green-Kubo formula
+Obtain Mobility by Green-Kubo Formula
 =====================================
 .. automodule:: renormalizer.transport.kubo
    :members:
 
-Charge diffusion dynamics simulation 
+Charge Diffusion Dynamics Simulation
 ====================================
 .. automodule:: renormalizer.transport.dynamics
    :members:

--- a/doc/source/install.md
+++ b/doc/source/install.md
@@ -90,6 +90,8 @@ Now, to install the required packages:
     ```
     pip install qutip==4.3.1
     ```
+> Sometimes an error will occur during the installation of `primme`, especially on Windows platform. Please refer to the [primme installation guide](https://github.com/primme/primme) for more details.
+
 #### Run tests
 To run tests, simply use the `pytest` command installed in the previous step in your Renormalizer source code directory:
 ```

--- a/renormalizer/cv/finitet.py
+++ b/renormalizer/cv/finitet.py
@@ -117,7 +117,7 @@ class SpectraFtCV(SpectraCv):
         if self.spectratype == "abs":
             dipole_mpo = Mpo.onsite(self.model, r"a^\dagger", dipole=True)
             i_mpo = MpDm.max_entangled_gs(self.model)
-            tp = ThermalProp(i_mpo, self.h_mpo, exact=True, space='GS')
+            tp = ThermalProp(i_mpo, exact=True, space='GS')
             tp.evolve(None, 1, beta / 2j)
             ket_mpo = tp.latest_mps
         elif self.spectratype == "emi":
@@ -135,7 +135,7 @@ class SpectraFtCV(SpectraCv):
                 else:
                     job_name = self.job_name + "_thermal_prop"
                 tp = ThermalProp(
-                    impo, self.h_mpo, evolve_config=self.evolve_config,
+                    impo, evolve_config=self.evolve_config,
                     dump_dir=self.dump_dir, job_name=job_name)
                 tp.evolve(None, self.insteps, beta / 2j)
                 ket_mpo = tp.latest_mps

--- a/renormalizer/mps/mp.py
+++ b/renormalizer/mps/mp.py
@@ -463,8 +463,7 @@ class MatrixProduct:
         """
 
         if mpo is None:
-            logger.info("Recommend to use svd to compress a single mps/mpo/mpdm.")
-            raise NotImplementedError
+            raise NotImplementedError("Recommend to use svd to compress a single mps/mpo/mpdm.")
         
         if guess is None:
             # a minimal representation of self and mpo

--- a/renormalizer/mps/mp.py
+++ b/renormalizer/mps/mp.py
@@ -408,7 +408,7 @@ class MatrixProduct:
         for idx in self.iter_idx_list(full=False):
             mt: Matrix = self[idx]
             qnbigl, qnbigr, _ = self._get_big_qn([idx])
-            u, sigma, qnlset, v, sigma, qnrset = svd_qn.Csvd(
+            u, sigma, qnlset, v, sigma, qnrset = svd_qn.svd_qn(
                 mt.array,
                 qnbigl,
                 qnbigr,
@@ -647,7 +647,7 @@ class MatrixProduct:
         if type(cstruct) is not list:
             # SVD method
             # full_matrices = True here to enable increase the bond dimension
-            Uset, SUset, qnlnew, Vset, SVset, qnrnew = svd_qn.Csvd(
+            Uset, SUset, qnlnew, Vset, SVset, qnrnew = svd_qn.svd_qn(
                 asnumpy(cstruct), qnbigl, qnbigr, self.qntot, system=system
             )
 
@@ -685,8 +685,9 @@ class MatrixProduct:
                         axes=(range(qnbigl.ndim), range(qnbigl.ndim)),
                     )
             ddm /= len(cstruct)
-            Uset, Sset, qnnew = svd_qn.Csvd(asnumpy(ddm), qnbigl, qnbigr, self.qntot,
-                    system=system, ddm=True)
+            Uset, Sset, qnnew = svd_qn.eigh_qn(
+                asnumpy(ddm), qnbigl, qnbigr, self.qntot, system=system
+            )
             ms, msdim, msqn, compms = select_basis(
                 Uset, Sset, qnnew, None, Mmax, percent=percent
             )
@@ -776,7 +777,7 @@ class MatrixProduct:
             assert mt.any()
             qnbigl, qnbigr, _ = self._get_big_qn([idx])
             system = "L" if self.to_right else "R"
-            u, qnlset, v, qnrset = svd_qn.Csvd(
+            u, qnlset, v, qnrset = svd_qn.svd_qn(
                 mt.array,
                 qnbigl,
                 qnbigr,

--- a/renormalizer/mps/mp.py
+++ b/renormalizer/mps/mp.py
@@ -481,8 +481,7 @@ class MatrixProduct:
         method = mps.compress_config.vmethod
 
         environ = Environ(self, mpo, "L", mps_conj=mps.conj())
-        
-        converged = False
+
         for isweep, (mmax, percent) in enumerate(procedure):
             logger.debug(f"isweep: {isweep}")
             logger.debug(f"mmax, percent: {mmax}, {percent}")
@@ -590,16 +589,15 @@ class MatrixProduct:
             
             mps._switch_direction()
             
-            # check if convergence
-            if isweep > 0 and percent == 0 and \
-                    mps.distance(mps_old) / np.sqrt(mps.dot(mps.conj()).real) < mps.compress_config.vrtol:
-                converged = True
-                break
+            # check convergence
+            if isweep > 0 and percent == 0:
+                error = mps.distance(mps_old) / np.sqrt(mps.dot(mps.conj()).real)
+                logger.info(f"Variation compress relative error: {error}")
+                if error < mps.compress_config.vrtol:
+                    logger.info("Variational compress is converged!")
+                    break
             
             mps_old = mps.copy()
-
-        if converged:
-            logger.info("Variational compress is converged!")
         else:
             logger.warning("Variational compress is not converged! Please increase the procedure!")
         

--- a/renormalizer/mps/mpo.py
+++ b/renormalizer/mps/mpo.py
@@ -107,13 +107,7 @@ def symbolic_mpo(table, factor, algo="Hopcroft-Karp"):
     
     The local mpo is the transformation matrix between 0'',1'' to 0'''
     """
-    logger.debug(f"symbolic mpo algorithm: {algo}")
-    # use np.uint32, np.uint16 to save memory
-    max_uint32 = np.iinfo(np.uint32).max
-    max_uint16 = np.iinfo(np.uint16).max
-    
-    nsite = len(table[0])
-    logger.debug(f"Input operator terms: {len(table)}")
+
     # Simplest case. Cut to the chase
     if len(table) == 1:
         # The first layer: number of sites. The 2nd and 3rd layer: in and out virtual bond
@@ -131,6 +125,14 @@ def symbolic_mpo(table, factor, algo="Hopcroft-Karp"):
         mpoqn[-1] = [0]
         qnidx = len(mpo) - 1
         return mpo, mpoqn, qntot, qnidx
+
+    # use np.uint32, np.uint16 to save memory
+    max_uint32 = np.iinfo(np.uint32).max
+    max_uint16 = np.iinfo(np.uint16).max
+
+    nsite = len(table[0])
+    logger.debug(f"symbolic mpo algorithm: {algo}")
+    logger.debug(f"Input operator terms: {len(table)}")
     # translate the symbolic operator table to an easy to manipulate numpy array
     # extract the op symbol, qn, factor to a numpy array
 

--- a/renormalizer/mps/mps.py
+++ b/renormalizer/mps/mps.py
@@ -461,7 +461,7 @@ class Mps(MatrixProduct):
             return np.array([self.expectation(mpo, self_conj) for mpo in mpos])
 
         # optimized way, cache for intermediates
-        # hash is used as indeces of the matrices.
+        # hash is used as indices of the matrices.
         # The chance for collision (the same hash for two different matrices) is
         # about 1-0.99999999999997 in 1000 matrices.
         # In which case a RuntimeError is raised and rerun the job should solve the problem

--- a/renormalizer/mps/mps.py
+++ b/renormalizer/mps/mps.py
@@ -833,7 +833,7 @@ class Mps(MatrixProduct):
                 if self.evolve_config.method == EvolveMethod.tdvp_mu_vmf:
                     # perform qr on the environment mps
                     qnbigl, qnbigr, _ = environ_mps._get_big_qn([imps + 1])
-                    u, s, qnlset, v, s, qnrset = svd_qn.Csvd(
+                    u, s, qnlset, v, s, qnrset = svd_qn.svd_qn(
                             environ_mps[imps + 1].array, qnbigl, qnbigr,
                             environ_mps.qntot, system="R", full_matrices=False)
                     vt = v.T
@@ -1035,7 +1035,7 @@ class Mps(MatrixProduct):
 
                 # perform qr on the environment mps
                 qnbigl, qnbigr, _ = environ_mps._get_big_qn([imps + 1])
-                u, s, qnlset, v, s, qnrset = svd_qn.Csvd(
+                u, s, qnlset, v, s, qnrset = svd_qn.svd_qn(
                     environ_mps[imps + 1].array,
                     qnbigl,
                     qnbigr,
@@ -1162,7 +1162,7 @@ class Mps(MatrixProduct):
                 mps_t = mps_t.reshape(shape)
 
                 qnbigl, qnbigr, _ = mps._get_big_qn([imps])
-                u, qnlset, v, qnrset = svd_qn.Csvd(
+                u, qnlset, v, qnrset = svd_qn.svd_qn(
                     asnumpy(mps_t),
                     qnbigl,
                     qnbigr,

--- a/renormalizer/mps/tests/test_mpdm.py
+++ b/renormalizer/mps/tests/test_mpdm.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 
-from renormalizer.mps import Mps, Mpo, MpDm, ThermalProp
+from renormalizer.mps import Mps, MpDm, ThermalProp
 from renormalizer.tests import parameter
 from renormalizer.utils import Quantity, EvolveConfig, EvolveMethod
 
@@ -28,7 +28,6 @@ def test_from_mps():
 def test_thermal_prop(adaptive, evolve_method):
     model = parameter.holstein_model
     init_mps = MpDm.max_entangled_ex(model)
-    mpo = Mpo(model)
     beta = Quantity(298, "K").to_beta()
     evolve_time = beta / 2j
 
@@ -48,7 +47,7 @@ def test_thermal_prop(adaptive, evolve_method):
 
     dbeta = evolve_time/nsteps
 
-    tp = ThermalProp(init_mps, mpo, evolve_config=evolve_config)
+    tp = ThermalProp(init_mps, evolve_config=evolve_config)
     tp.evolve(evolve_dt=dbeta, nsteps=nsteps)
     # MPO, HAM, Etot, A_el = mps.construct_hybrid_Ham(mpo, debug=True)
     # exact A_el: 0.20896541050347484, 0.35240029674394463, 0.4386342927525734

--- a/renormalizer/mps/tests/test_mpproperty.py
+++ b/renormalizer/mps/tests/test_mpproperty.py
@@ -32,7 +32,7 @@ def test_mps():
 def test_mpo():
     gs_dm = MpDm.max_entangled_gs(holstein_model)
     beta = Quantity(10, "K").to_beta()
-    tp = ThermalProp(gs_dm, Mpo(gs_dm.model), exact=True, space="GS")
+    tp = ThermalProp(gs_dm, exact=True, space="GS")
     tp.evolve(None, 500, beta / 1j)
     gs_dm = tp.latest_mps
     mp = creation_operator @ gs_dm

--- a/renormalizer/mps/tests/test_sbm.py
+++ b/renormalizer/mps/tests/test_sbm.py
@@ -46,7 +46,7 @@ def test_ft():
     impdm.compress_config = CompressConfig(threshold=1e-6)
     temperature = Quantity(3)
     evolve_config = EvolveConfig(adaptive=True, guess_dt=-0.001j)
-    tp = ThermalProp(impdm, mpo, evolve_config=evolve_config)
+    tp = ThermalProp(impdm, evolve_config=evolve_config)
     tp.evolve(nsteps=1, evolve_time=temperature.to_beta() / 2j)
     mpdm = tp.latest_mps
     mpdm = Mpo(model, Op("sigma_x", "spin")).contract(mpdm)

--- a/renormalizer/mps/thermalprop.py
+++ b/renormalizer/mps/thermalprop.py
@@ -2,6 +2,7 @@ import logging
 
 import numpy as np
 
+from renormalizer.model import Model
 from renormalizer.mps import MpDm, Mpo
 from renormalizer.utils import TdMpsJob, Quantity, EvolveConfig
 from renormalizer.property import Property
@@ -15,7 +16,8 @@ class ThermalProp(TdMpsJob):
 
     Args:
         init_mpdm (:class:`~renormalizer.mps.MpDm`): the initial density matrix to be propagated. Usually identity.
-        h_mpo (:class:`~renormalizer.mps.Mpo`): the system Hamiltonian.
+        h_mpo_model (:class:`~renormalizer.model.model.Model`): Model for the system Hamiltonian.
+            Default is the same with ``init_mpdm.model``.
         exact (bool): whether propagate assuming Hamiltonian is local
             :math:`\hat H = \sum_i \hat H_i = \sum_{in} \omega_{in} b^\dagger_{in} b_{in}` and
             exact propagation is possible through :math:`e^{xH} = e^{xh_1}e^{xh_2} \cdots e^{xh_n}`.
@@ -34,7 +36,7 @@ class ThermalProp(TdMpsJob):
     def __init__(
         self,
         init_mpdm: MpDm,
-        h_mpo: Mpo,
+        h_mpo_model: Model = None,
         exact: bool = False,
         space: str = "GS",
         evolve_config: EvolveConfig = None,
@@ -45,8 +47,10 @@ class ThermalProp(TdMpsJob):
         auto_expand: bool = True,
     ):
         self.init_mpdm: MpDm = init_mpdm.canonicalise()
-        # todo: remove h_mpo. construct from init_mpdm.model
-        self.h_mpo = h_mpo
+        if h_mpo_model is None:
+            h_mpo_model = self.init_mpdm.model
+        self.h_mpo = Mpo(h_mpo_model)
+        logger.info(f"Bond dim of h_mpo: {self.h_mpo.bond_dims}")
         self.exact = exact
         assert space in ["GS", "EX"]
         self.space = space

--- a/renormalizer/mps/thermalprop.py
+++ b/renormalizer/mps/thermalprop.py
@@ -71,11 +71,11 @@ class ThermalProp(TdMpsJob):
         return self.init_mpdm
 
     def process_mps(self, mps):
+        new_energy = mps.expectation(self.h_mpo)
+        self.energies.append(new_energy)
         if self.exact:
             # skip the fuss for efficiency
             return
-        new_energy = mps.expectation(self.h_mpo)
-        self.energies.append(new_energy)
         for attr_str in ["e_occupations", "ph_occupations"]:
             attr = getattr(mps, attr_str)
             logger.info(f"{attr_str}: {attr}")
@@ -94,7 +94,7 @@ class ThermalProp(TdMpsJob):
 
     def evolve_exact(self, old_mpdm: MpDm, evolve_dt):
         MPOprop = Mpo.exact_propagator(
-            old_mpdm.model, evolve_dt.imag, space=self.space, shift=-self.h_mpo.offset
+            old_mpdm.model, evolve_dt.imag, space=self.space, shift=-self.energies[-1]
         )
         new_mpdm = MPOprop.apply(old_mpdm, canonicalise=True)
         # partition function can't be obtained. It's not practical anyway.

--- a/renormalizer/property/tests/test_polaron_structure.py
+++ b/renormalizer/property/tests/test_polaron_structure.py
@@ -100,7 +100,7 @@ def test_thermal_equilibrium(periodic):
     #init_mpdm.compress_config.bond_dim_max_value=10
     init_mpdm.compress_config.threshold = 1e-4
     
-    td = ThermalProp(init_mpdm, mpo, evolve_config=evolve_config,
+    td = ThermalProp(init_mpdm, evolve_config=evolve_config,
             dump_dir=dump_dir, job_name=job_name, properties=prop)
     td.evolve(dbeta, nsteps=nsteps)
     

--- a/renormalizer/spectra/exact.py
+++ b/renormalizer/spectra/exact.py
@@ -80,7 +80,7 @@ class SpectraExact(SpectraTdMpsJobBase):
             # ket_mps.normalize()
             # no test, don't know work or not
             i_mpdm = MpDm.from_mps(i_mps)
-            tp = ThermalProp(i_mpdm, self.h_mpo, exact=True, space=self.space1)
+            tp = ThermalProp(i_mpdm, exact=True, space=self.space1)
             tp.evolve(None, 1, beta / 2j)
             ket_mps = tp.latest_mps
         else:

--- a/renormalizer/spectra/finitet.py
+++ b/renormalizer/spectra/finitet.py
@@ -74,7 +74,7 @@ class SpectraFiniteT(SpectraTdMpsJobBase):
             job_name = self.job_name + "_thermal_prop"
         # only propagate half beta
         tp = ThermalProp(
-            i_mpo, self.h_mpo, evolve_config=self.ievolve_config,
+            i_mpo, evolve_config=self.ievolve_config,
             dump_dir=self.dump_dir, job_name=job_name
         )
         if tp._defined_output_path:
@@ -126,7 +126,7 @@ class SpectraFiniteT(SpectraTdMpsJobBase):
         i_mpo = MpDm.max_entangled_gs(self.model)
         i_mpo.compress_config = self.icompress_config
         beta = self.temperature.to_beta()
-        tp = ThermalProp(i_mpo, self.h_mpo, exact=True, space="GS")
+        tp = ThermalProp(i_mpo, exact=True, space="GS")
         tp.evolve(None, 1, beta / 2j)
         ket_mpo = tp.latest_mps
         ket_mpo.evolve_config = self.evolve_config

--- a/renormalizer/transport/dynamics.py
+++ b/renormalizer/transport/dynamics.py
@@ -173,7 +173,7 @@ class ChargeDiffusionDynamics(TdMpsJob):
                 # subtract the energy otherwise might cause numeric error because of large offset * dbeta
                 energy = Quantity(gs_mp.expectation(tentative_mpo))
                 mpo = Mpo(self.model, offset=energy)
-                tp = ThermalProp(gs_mp, mpo, exact=True, space="GS")
+                tp = ThermalProp(gs_mp, exact=True, space="GS")
                 tp.evolve(None, max(20, len(gs_mp)), self.temperature.to_beta() / 2j)
                 gs_mp = tp.latest_mps
                 if self._defined_output_path:
@@ -254,7 +254,7 @@ class ChargeDiffusionDynamics(TdMpsJob):
         dump_dict["bond entropy"] = self.bond_vn_entropy_array
         dump_dict["coherent length array"] = self.coherent_length_array
         if self.reduced_density_matrices:
-            dump_dict["reduced density matrices"] = self.reduced_density_matrices[-1]
+            dump_dict["reduced density matrices"] = self.reduced_density_matrices
         dump_dict["time series"] = list(self.evolve_times)
         return dump_dict
 

--- a/renormalizer/transport/kubo.py
+++ b/renormalizer/transport/kubo.py
@@ -127,7 +127,7 @@ class TransportKubo(TdMpsJob):
         if thermal_dump_path is not None:
             self.thermal_dump_path = thermal_dump_path
         elif dump_dir is not None and job_name is not None:
-            self.thermal_dump_path = os.path.join(self.dump_dir, self.job_name + '_impdm.npz')
+            self.thermal_dump_path = os.path.join(dump_dir, job_name + '_impdm.npz')
         else:
             self.thermal_dump_path = None
 

--- a/renormalizer/transport/kubo.py
+++ b/renormalizer/transport/kubo.py
@@ -67,6 +67,7 @@ class TransportKubo(TdMpsJob):
             Zero temperature is not supported.
         distance_matrix (:class:`np.ndarray`): two-dimensional array :math:`D_{ij} = P_i - P_j` representing
             distance between the :math:`i` th electronic degree of freedom and the :math:`j` th degree of freedom.
+            The index is the same with ``model.e_dofs``.
             The parameter takes the role of :math:`\hat P` and can better handle periodic boundary condition.
             The default value is ``None`` in which case the distance matrix is constructed assuming the system
             is a one-dimensional chain.
@@ -217,7 +218,7 @@ class TransportKubo(TdMpsJob):
                 job_name = None
             else:
                 job_name = self.job_name + "_thermal_prop"
-            tp = ThermalProp(i_mpdm, self.h_mpo, evolve_config=self.ievolve_config, dump_dir=self.dump_dir, job_name=job_name)
+            tp = ThermalProp(i_mpdm, evolve_config=self.ievolve_config, dump_dir=self.dump_dir, job_name=job_name)
             # only propagate half beta
             tp.evolve(None, self.insteps, self.temperature.to_beta() / 2j)
             mpdm = tp.latest_mps

--- a/renormalizer/transport/tests/test_dynamics.py
+++ b/renormalizer/transport/tests/test_dynamics.py
@@ -141,33 +141,3 @@ def test_evolve(
     ct2.job_name = "test"
     ct2.dump_dict()
     os.remove("test.npz")
-
-
-@pytest.mark.parametrize(
-    "mol_num, j_constant_value, elocalex_value, ph_info, ph_phys_dim, evolve_dt, nsteps",
-    ([3, 1, 3.87e-3, [[1e-5, 1e-5]], 2, 2, 50],),
-)
-@pytest.mark.parametrize("scheme", (3, 4))
-def test_band_limit_finite_t(
-    mol_num,
-    j_constant_value,
-    elocalex_value,
-    ph_info,
-    ph_phys_dim,
-    evolve_dt,
-    nsteps,
-    scheme,
-):
-    ph_list = [
-        Phonon.simple_phonon(
-            Quantity(omega, "cm^{-1}"), Quantity(displacement, "a.u."), ph_phys_dim
-        )
-        for omega, displacement in ph_info
-    ]
-    model = HolsteinModel([Mol(Quantity(elocalex_value, "a.u."), ph_list)] * mol_num,
-                             Quantity(j_constant_value, "eV"), )
-    ct1 = ChargeDiffusionDynamics(model, stop_at_edge=False)
-    ct1.evolve(evolve_dt, nsteps)
-    ct2 = ChargeDiffusionDynamics(model, temperature=low_t, stop_at_edge=False)
-    ct2.evolve(evolve_dt, nsteps)
-    assert ct1.is_similar(ct2)

--- a/renormalizer/utils/tdmps.py
+++ b/renormalizer/utils/tdmps.py
@@ -33,6 +33,7 @@ class TdMpsJob(object):
         self.dump_dir = dump_dir
         self.job_name = job_name
         mps = self.init_mps()
+        logger.info(f"Initial MPS: {str(mps)}")
         if mps is None:
             raise ValueError("init_mps should return an mps. Got None")
         self.latest_mps = mps
@@ -206,12 +207,3 @@ class TdMpsJob(object):
     @property
     def _defined_output_path(self):
         return self.dump_dir is not None and self.job_name is not None
-
-    @property
-    def _thermal_dump_path(self):
-        """
-        The path where thermal propagated states should be dumped or loaded
-        Returns: string of the path
-        """
-        assert self._defined_output_path
-        return os.path.join(self.dump_dir, self.job_name + '_impdm.npz')


### PR DESCRIPTION
The PR contains three commits (and two bugfix commits):
- Update the interface for `ThermalProp` as mentioned in #110 . `h_mpo` is replaced by `h_mpo_model`, which is used to construct `h_mpo` at every imaginary time step. 
- Allow manually setting thermal dump path in `TransportKubo`.
- Optimize `Csvd`. When `full_matrices` is set to `True`, the routine is particularly time-consuming for matrices with imbalanced shape, such as (100, 100\*40\*40). However, in almost all cases it is not necessary to construct the complete matrix (100\*40\*40, 100\*40\*40) as required by `full_matrices=True`. The optimization contained in this PR is to set `full_matrices=False` and add additional Gram-Schmidt orthonormalized basis to the matrices after SVD decomposition. The number of the basis is set to be equal to the dimension of the smaller index (100 in the above dimension). The update should allow dynamic growth of bond dimension while gaining tremendous efficiency when the shape of the matrix to be decomposed is imbalanced.
    The same optimization can be carried out for QR but for now QR is only used with `full_matrices=False`, so the code for QR is not modified.

At first I decided to remove the finite temperature interface for `ChargeDiffusionDynamics` since using Bogoliubov transformation is more convenient. However `ChargeDiffusionDynamics` is based on `HolsteinModel` and using Bogoliubov transformation is not straight-forward.