### PR TITLE
Implement 2site-TDVP-PS algorithm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 
 python:
     - "3.6"
+    - "3.7"
 
 before_install:
     - sudo apt-get -y install libblas-dev liblapack-dev

--- a/renormalizer/lib/krylov/krylov.py
+++ b/renormalizer/lib/krylov/krylov.py
@@ -34,6 +34,8 @@ def expm_krylov(Afunc, dt, vstart: xp.ndarray, block_size=50):
         On Krylov subspace approximations to the matrix exponential operator
         SIAM J. Numer. Anal. 34, 1911 (1997)
     """
+    if not np.iscomplex(dt):
+        dt = float(dt)
 
     # normalize starting vector
     vstart = xp.asarray(vstart)

--- a/renormalizer/lib/krylov/krylov.py
+++ b/renormalizer/lib/krylov/krylov.py
@@ -35,7 +35,7 @@ def expm_krylov(Afunc, dt, vstart: xp.ndarray, block_size=50):
         SIAM J. Numer. Anal. 34, 1911 (1997)
     """
     if not np.iscomplex(dt):
-        dt = float(dt)
+        dt = dt.real
 
     # normalize starting vector
     vstart = xp.asarray(vstart)

--- a/renormalizer/mps/gs.py
+++ b/renormalizer/mps/gs.py
@@ -17,6 +17,7 @@ import primme
 from renormalizer.lib import davidson
 from renormalizer.mps.backend import xp, OE_BACKEND
 from renormalizer.mps.matrix import multi_tensor_contract, tensordot, asnumpy, asxp
+from renormalizer.mps.hop_expr import  hop_expr
 from renormalizer.mps import Mpo, Mps
 from renormalizer.mps.lib import Environ, cvec2cmat
 from renormalizer.utils import Quantity
@@ -402,52 +403,7 @@ def eigh_iterative(
 
     # contraction expression
     cshape = qnmat.shape
-    if omega is None:
-        if method == "1site":
-            # S-a   l-S
-            #     d
-            # O-b-O-f-O
-            #     e
-            # S-c   k-S
-            expr = oe.contract_expression(
-                "abc, bdef, lfk, adl -> cek",
-                ltensor, cmo[0], rtensor, cshape,
-                constants=[0, 1, 2],
-            )
-        else:
-            # S-a       l-S
-            #     d   g
-            # O-b-O-f-O-j-O
-            #     e   h
-            # S-c       k-S
-            expr = oe.contract_expression(
-                "abc, bdef, fghj, ljk, adgl -> cehk",
-                ltensor, cmo[0], cmo[1], rtensor, cshape,
-                constants=[0, 1, 2, 3],
-            )
-    else:
-        if method == "1site":
-            #   S-a e j-S
-            #   O-b-O-g-O
-            #   |   f   |
-            #   O-c-O-i-O
-            #   S-d h k-S
-            expr = oe.contract_expression(
-                "abcd, befg, cfhi, jgik, aej -> dhk",
-                ltensor, cmo[0], cmo[0], rtensor, cshape,
-                constants=[0, 1, 2, 3],
-            )
-        else:
-            #   S-a e   j o-S
-            #   O-b-O-g-O-l-O
-            #   |   f   k   |
-            #   O-c-O-i-O-n-O
-            #   S-d h   m p-S
-            expr = oe.contract_expression(
-                "abcd, befg, cfhi, gjkl, ikmn, olnp, aejo -> dhmp",
-                ltensor, cmo[0], cmo[0], cmo[1], cmo[1], rtensor, cshape,
-                constants=[0, 1, 2, 3, 4, 5],
-            )
+    expr = hop_expr(ltensor, rtensor, cmo, cshape, omega is not None)
 
     count = 0
 

--- a/renormalizer/mps/hop_expr.py
+++ b/renormalizer/mps/hop_expr.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+
+import opt_einsum as oe
+
+from renormalizer.mps.matrix import asxp
+
+
+def hop_expr(ltensor, rtensor, cmo, cshape, twolayer:bool=False):
+
+    nsite = len(cmo)
+    # whether have the ancilla
+    ancilla = 2 * nsite + 2 == len(cshape)
+    if not ancilla:
+        assert nsite + 2 == len(cshape)
+
+    ltensor = asxp(ltensor)
+    rtensor = asxp(rtensor)
+    for i in range(len(cmo)):
+        cmo[i] = asxp(cmo[i])
+
+    if twolayer:
+        assert nsite in [1, 2]
+        # Only used in ground state algorithm
+        # Hopefully generalize to CV in the future
+        assert not ancilla
+        if nsite == 1:
+            #   S-a e j-S
+            #   O-b-O-g-O
+            #   |   f   |
+            #   O-c-O-i-O
+            #   S-d h k-S
+            expr = oe.contract_expression(
+                "abcd, befg, cfhi, jgik, aej -> dhk",
+                ltensor, cmo[0], cmo[0], rtensor, cshape,
+                constants=[0, 1, 2, 3]
+            )
+        else:
+            #   S-a e   j o-S
+            #   O-b-O-g-O-l-O
+            #   |   f   k   |
+            #   O-c-O-i-O-n-O
+            #   S-d h   m p-S
+            expr = oe.contract_expression(
+                "abcd, befg, cfhi, gjkl, ikmn, olnp, aejo -> dhmp",
+                ltensor, cmo[0], cmo[0], cmo[1], cmo[1], rtensor, cshape,
+                constants=[0, 1, 2, 3, 4, 5],
+            )
+        # early return
+        return expr
+
+    # Single layer, the most common case
+    # Could be written in an automatic way
+    # But for now probably an overkill
+    if nsite == 0:
+        # S-a   l-S
+        #
+        # O-b - b-O
+        #
+        # S-c   k-S
+        expr = oe.contract_expression(
+            "abc, lbk, ck -> al",
+            ltensor, rtensor, cshape,
+            constants=[0, 1],
+        )
+    elif nsite == 1:
+        if not ancilla:
+            # S-a   l-S
+            #     d
+            # O-b-O-f-O
+            #     e
+            # S-c   k-S
+            expr = oe.contract_expression(
+                "abc, bdef, lfk, cek -> adl",
+                ltensor, cmo[0], rtensor, cshape,
+                constants=[0, 1, 2],
+            )
+        else:
+            # S-a   l-S
+            #     d
+            # O-b-O-f-O
+            #     e
+            # S-c   k-S
+            #     g
+            expr = oe.contract_expression(
+                "abc, bdef, lfk, cegk -> adgl",
+                ltensor, cmo[0], rtensor, cshape,
+                constants=[0, 1, 2],
+            )
+    else:
+        if not ancilla:
+            # S-a       l-S
+            #     d   g
+            # O-b-O-f-O-j-O
+            #     e   h
+            # S-c       k-S
+            expr = oe.contract_expression(
+                "abc, bdef, fghj, ljk, cehk -> adgl",
+                ltensor, cmo[0], cmo[1], rtensor, cshape,
+                constants=[0, 1, 2, 3],
+            )
+        else:
+            # S-a       l-S
+            #     d   g
+            # O-b-O-f-O-j-O
+            #     e   h
+            # S-c       k-S
+            #     m   n
+            expr = oe.contract_expression(
+                "abc, bdef, fghj, ljk, cemhnk -> admgnl",
+                ltensor, cmo[0], cmo[1], rtensor, cshape,
+                constants=[0, 1, 2, 3],
+            )
+
+    return expr

--- a/renormalizer/mps/hop_expr.py
+++ b/renormalizer/mps/hop_expr.py
@@ -18,6 +18,10 @@ def hop_expr(ltensor, rtensor, cmo, cshape, twolayer:bool=False):
     for i in range(len(cmo)):
         cmo[i] = asxp(cmo[i])
 
+    if nsite == 0:
+        # ancilla not defined
+        del ancilla
+
     if twolayer:
         assert nsite in [1, 2]
         # Only used in ground state algorithm

--- a/renormalizer/mps/mp.py
+++ b/renormalizer/mps/mp.py
@@ -765,6 +765,30 @@ class MatrixProduct:
         else:
             return None
 
+
+    def _push_cano(self, idx, normalize=False):
+        # move the canonical center to the next site
+        # idx is the current canonical center
+        mt: Matrix = self[idx]
+        assert mt.any()
+        qnbigl, qnbigr, _ = self._get_big_qn([idx])
+        system = "L" if self.to_right else "R"
+        u, qnlset, v, qnrset = svd_qn.svd_qn(
+            mt.array,
+            qnbigl,
+            qnbigr,
+            self.qntot,
+            QR=True,
+            system=system,
+            full_matrices=False,
+        )
+        if normalize:
+            # roughly normalize. Used when the each site of the mps is scaled such as in exact thermal prop
+            v /= np.linalg.norm(v[:, 0])
+        self._update_ms(
+            idx, u, v.T, sigma=None, qnlset=qnlset, qnrset=qnrset
+        )
+
     def canonicalise(self, stop_idx: int=None, normalize=False):
         # stop_idx: mix canonical site at `stop_idx`
         if self.to_right:
@@ -773,25 +797,7 @@ class MatrixProduct:
             assert self.qnidx == self.site_num-1
 
         for idx in self.iter_idx_list(full=False, stop_idx=stop_idx):
-            mt: Matrix = self[idx]
-            assert mt.any()
-            qnbigl, qnbigr, _ = self._get_big_qn([idx])
-            system = "L" if self.to_right else "R"
-            u, qnlset, v, qnrset = svd_qn.svd_qn(
-                mt.array,
-                qnbigl,
-                qnbigr,
-                self.qntot,
-                QR=True,
-                system=system,
-                full_matrices=False,
-            )
-            if normalize:
-                # roughly normalize. Used when the each site of the mps is scaled such as in exact thermal prop
-                v /= np.linalg.norm(v[:, 0])
-            self._update_ms(
-                idx, u, v.T, sigma=None, qnlset=qnlset, qnrset=qnrset
-            )
+           self._push_cano(idx, normalize)
         # can't iter to idx == 0 or idx == self.site_num - 1
         if (not self.to_right and idx == 1) or (self.to_right and idx == self.site_num - 2):
             self._switch_direction()

--- a/renormalizer/mps/mp.py
+++ b/renormalizer/mps/mp.py
@@ -1024,5 +1024,5 @@ class MatrixProduct:
         if os.path.exists(dir_with_id):
             try:
                 shutil.rmtree(dir_with_id)
-            except:
+            except OSError:
                 logger.exception(f"Removing temperary dump dir {dir_with_id} failed")

--- a/renormalizer/mps/mp.py
+++ b/renormalizer/mps/mp.py
@@ -766,7 +766,7 @@ class MatrixProduct:
             return None
 
 
-    def _push_cano(self, idx, normalize=False):
+    def _push_cano(self, idx):
         # move the canonical center to the next site
         # idx is the current canonical center
         mt: Matrix = self[idx]
@@ -782,14 +782,11 @@ class MatrixProduct:
             system=system,
             full_matrices=False,
         )
-        if normalize:
-            # roughly normalize. Used when the each site of the mps is scaled such as in exact thermal prop
-            v /= np.linalg.norm(v[:, 0])
         self._update_ms(
             idx, u, v.T, sigma=None, qnlset=qnlset, qnrset=qnrset
         )
 
-    def canonicalise(self, stop_idx: int=None, normalize=False):
+    def canonicalise(self, stop_idx: int=None):
         # stop_idx: mix canonical site at `stop_idx`
         if self.to_right:
             assert self.qnidx == 0
@@ -797,7 +794,7 @@ class MatrixProduct:
             assert self.qnidx == self.site_num-1
 
         for idx in self.iter_idx_list(full=False, stop_idx=stop_idx):
-           self._push_cano(idx, normalize)
+           self._push_cano(idx)
         # can't iter to idx == 0 or idx == self.site_num - 1
         if (not self.to_right and idx == 1) or (self.to_right and idx == self.site_num - 2):
             self._switch_direction()

--- a/renormalizer/mps/mps.py
+++ b/renormalizer/mps/mps.py
@@ -1573,7 +1573,7 @@ def integrand_func_factory(
     # Ovlp0 is (#.conj, #), Ovlp_inv0 = (#, #.conj), Ovlp_inv1 = (#, #.conj)
     # S_inv is (#.conj, #)
     def func(t, y):
-        y0 = y.reshape(shape)
+        y0 = asxp(y.reshape(shape))
         HC = hop(y0)
         if not islast:
             proj = projector(y0, left, ovlp_inv1, ovlp0)

--- a/renormalizer/mps/tests/test_evolve.py
+++ b/renormalizer/mps/tests/test_evolve.py
@@ -96,6 +96,20 @@ def test_tdvp_ps(init_state, mpo):
     mps.evolve_config  = EvolveConfig(EvolveMethod.tdvp_ps)
     check_result(mps, mpo, 0.4, 5)
 
+
+@pytest.mark.parametrize("init_state, mpo", (
+        [init_mps, mpo],
+        [init_mpdm, mpo],
+))
+def test_tdvp_ps2(init_state, mpo):
+    mps = init_state.copy()
+    mps.evolve_config  = EvolveConfig(EvolveMethod.tdvp_ps2)
+    mps.compress_config = CompressConfig(max_bonddim=5)
+    # lower accuracy because of the truncation,
+    # which is included to test the ability of adjusting bond dimension
+    mps = check_result(mps, mpo, 0.4, 5, atol=5e-4)
+    assert max(mps.bond_dims) == 5
+
 # used for debugging
 def compare():
     dt_list = [0.01, 0.02, 0.05, 0.1, 0.2, 0.4]

--- a/renormalizer/mps/tests/test_evolve.py
+++ b/renormalizer/mps/tests/test_evolve.py
@@ -22,7 +22,7 @@ def f(model, run_qutip=True):
         # calculate result in ZT. FT result is exactly the same
         TIME_LIMIT = 10
         QUTIP_STEP = 0.01
-        N_POINTS = TIME_LIMIT / QUTIP_STEP + 1
+        N_POINTS = int(TIME_LIMIT / QUTIP_STEP + 1)
         qutip_time_series = np.linspace(0, TIME_LIMIT, N_POINTS)
         init = qutip.Qobj(init_mps.full_wfn(), [qutip_h.dims[0], [1] * len(qutip_h.dims[0])])
         # the result is not exact and the error scale is approximately 1e-5

--- a/renormalizer/utils/configs.py
+++ b/renormalizer/utils/configs.py
@@ -296,15 +296,17 @@ class EvolveMethod(Enum):
     """
     Time evolution methods.
     """
-    #: propagation and compression with RK45 propagator
+    # propagation and compression with RK45 propagator
     prop_and_compress = "P&C"
-    #: TDVP with projector splitting
-    tdvp_ps = "TDVP_PS"
-    #: TDVP with variable mean field (VMF)
+    # TDVP with projector splitting - one site
+    tdvp_ps = "TDVP PS one-site"
+    # TDVP with projector splitting - two site
+    tdvp_ps2 = "TDVP PS two-site"
+    # TDVP with variable mean field (VMF)
     tdvp_vmf = "TDVP Variable Mean Field"
-    #: TDVP with constant mean field (CMF) and matrix unfolding (MU) regularization
+    # TDVP with constant mean field (CMF) and matrix unfolding (MU) regularization
     tdvp_mu_cmf = "TDVP Matrix Unfolding Constant Mean Field"
-    #: TDVP with variable mean field (VMF) and matrix unfolding (MU) regularization
+    # TDVP with variable mean field (VMF) and matrix unfolding (MU) regularization
     tdvp_mu_vmf = "TDVP Matrix Unfolding Variable Mean Field"
 
 


### PR DESCRIPTION
Implement the two-site TDVP-PS algorithm. Only tested in the test suite and not in production environment yet.
- Create a new file `hop_expr.py` in the `mps` directory, responsible for constructing the contract expression of applying H operator, based on `opt_einsum`
- Remove the `USE_RK` option in one-site TDVP-PS
- It turs out that the two-site TDVP-PS algorithms is more easy to implement than the one-site algorithm because most subroutines are readily available. 