### PR TITLE
add loading mps from dense wfn

### DIFF
--- a/renormalizer/mps/mp.py
+++ b/renormalizer/mps/mp.py
@@ -32,6 +32,24 @@ logger = logging.getLogger(__name__)
 
 class MatrixProduct:
 
+    @classmethod
+    def load(cls, model: Model, fname: str):
+        npload = np.load(fname, allow_pickle=True)
+        mp = cls()
+        mp.model = model
+        for i in range(int(npload["nsites"])):
+            mt = npload[f"mt_{i}"]
+            if np.iscomplexobj(mt):
+                mp.dtype = backend.complex_dtype
+            else:
+                mp.dtype = backend.real_dtype
+            mp.append(mt)
+        mp.qn = npload["qn"]
+        mp.qnidx = int(npload["qnidx"])
+        mp.qntot = int(npload["qntot"])
+        mp.to_right = bool(npload["to_right"])
+        return mp
+
     def __init__(self):
         # XXX: when modify theses codes, keep in mind to update `metacopy` method
         # set to a list of None upon metacopy. String is used when the matrix is
@@ -974,24 +992,6 @@ class MatrixProduct:
             np.savez(fname, **data_dict)
         except Exception:
             logger.exception(f"Dump MP failed.")
-    
-    @classmethod
-    def load(cls, model: Model, fname: str):
-        npload = np.load(fname, allow_pickle=True)
-        mp = cls()
-        mp.model = model
-        for i in range(int(npload["nsites"])):
-            mt = npload[f"mt_{i}"]
-            if np.iscomplexobj(mt):
-                mp.dtype = backend.complex_dtype
-            else:
-                mp.dtype = backend.real_dtype
-            mp.append(mt)
-        mp.qn = npload["qn"]
-        mp.qnidx = int(npload["qnidx"])
-        mp.qntot = int(npload["qntot"])
-        mp.to_right = bool(npload["to_right"])
-        return mp
 
     @property
     def total_bytes(self):

--- a/renormalizer/mps/mpdm.py
+++ b/renormalizer/mps/mpdm.py
@@ -47,6 +47,10 @@ class MpDm(Mps, Mpo):
         return mpo
 
     @classmethod
+    def from_dense(cls, model, wfn: np.ndarray):
+        raise NotImplementedError
+
+    @classmethod
     def max_entangled_ex(cls, model, normalize=True):
         """
         T = \\infty locally maximal entangled EX state
@@ -78,8 +82,9 @@ class MpDm(Mps, Mpo):
         new_mpdm.coeff *= np.exp(-1.0j * h_mpo.offset * evolve_dt)
         return new_mpdm
 
-    def full_wfn(self):
-        raise NotImplementedError("Use full_operator on Matrix Product Density Matrix")
+    def todense(self):
+        # explicitly call to MPO because MPS is firstly inherited
+        return Mpo.todense(self)
 
     @property
     def is_mps(self):

--- a/renormalizer/mps/mpo.py
+++ b/renormalizer/mps/mpo.py
@@ -454,7 +454,7 @@ class Mpo(MatrixProduct):
         new_mpo.qn = [[-i for i in mt_qn] for mt_qn in new_mpo.qn]
         return new_mpo
 
-    def full_operator(self):
+    def todense(self):
         dim = np.prod(self.pbond_list)
         if 20000 < dim:
             raise ValueError("operator too large")
@@ -467,7 +467,7 @@ class Mpo(MatrixProduct):
         return res[0, :, :, 0]
 
     def is_hermitian(self):
-        full = self.full_operator()
+        full = self.todense()
         return np.allclose(full.conj().T, full, atol=1e-7)
 
     def __matmul__(self, other):

--- a/renormalizer/mps/tests/test_evolve.py
+++ b/renormalizer/mps/tests/test_evolve.py
@@ -30,7 +30,7 @@ def f(model, run_qutip=True):
         QUTIP_STEP = 0.01
         N_POINTS = int(TIME_LIMIT / QUTIP_STEP + 1)
         qutip_time_series = np.linspace(0, TIME_LIMIT, N_POINTS)
-        init = qutip.Qobj(init_mps.full_wfn(), [qutip_h.dims[0], [1] * len(qutip_h.dims[0])])
+        init = qutip.Qobj(init_mps.todense(), [qutip_h.dims[0], [1] * len(qutip_h.dims[0])])
         # the result is not exact and the error scale is approximately 1e-5
         res = qutip.sesolve(qutip_h-e, init, qutip_time_series, e_ops=[c.dag() * c for c in qutip_clist])
         qutip_expectations = np.array(res.expect).T

--- a/renormalizer/mps/tests/test_mp.py
+++ b/renormalizer/mps/tests/test_mp.py
@@ -30,8 +30,8 @@ def test_save_load():
 def check_distance(a: Mps, b: Mps):
     d1 = (a - b).dmrg_norm
     d2 = a.distance(b)
-    a_array = a.full_wfn()
-    b_array = b.full_wfn()
+    a_array = a.todense()
+    b_array = b.todense()
     d3 = np.linalg.norm(a_array - b_array)
     assert d1 == pytest.approx(d2) == pytest.approx(d3)
 

--- a/renormalizer/mps/tests/test_mpo.py
+++ b/renormalizer/mps/tests/test_mpo.py
@@ -35,7 +35,7 @@ def test_symbolic_mpo(nsites, nterms):
     basis = [BasisHalfSpin(i) for i in range(nsites)]
     model = Model(basis, ham_terms)
     mpo = Mpo(model)
-    dense_mpo = mpo.full_operator()
+    dense_mpo = mpo.todense()
     qutip_ham = get_spin_hamiltonian(ham_terms)
     assert np.allclose(dense_mpo, qutip_ham.data.todense())
 
@@ -65,8 +65,8 @@ def test_swap_symbolic_mpo(nsites, nterms):
         new_model = Model(basis, ham_terms)
         mpo.try_swap_site(new_model, False)
         ref_mpo = Mpo(new_model)
-        mpo_dense = mpo.full_operator()
-        ref_dense = ref_mpo.full_operator()
+        mpo_dense = mpo.todense()
+        ref_dense = ref_mpo.todense()
         assert np.allclose(mpo_dense, ref_dense)
 
 
@@ -86,11 +86,11 @@ def test_offset(scheme):
     mlist = HolsteinModel([m] * 2, Quantity(17), )
     mpo1 = Mpo(mlist)
     assert mpo1.is_hermitian()
-    f1 = mpo1.full_operator()
+    f1 = mpo1.todense()
     evals1, _ = np.linalg.eigh(f1)
     offset = Quantity(0.123)
     mpo2 = Mpo(mlist, offset=offset)
-    f2 = mpo2.full_operator()
+    f2 = mpo2.todense()
     evals2, _ = np.linalg.eigh(f2)
     assert np.allclose(evals1 - offset.as_au(), evals2)
 
@@ -110,7 +110,7 @@ def test_scheme4():
     mpo4 = Mpo(model4)
     assert mpo4.is_hermitian()
     # for debugging
-    f = mpo4.full_operator()
+    f = mpo4.todense()
     mpo3 = Mpo(model3)
     assert mpo3.is_hermitian()
     # makeup two states

--- a/renormalizer/mps/tests/test_mps.py
+++ b/renormalizer/mps/tests/test_mps.py
@@ -70,6 +70,7 @@ def test_reduced_density_matrix():
              BasisMultiElectronVac([2, 3]), BasisSHO("v2", 1, 2), BasisSHO("v3", 1, 2)]
     check_reduced_density_matrix(basis)
 
+
 def test_site_entropy():
     mps = Mps.random(parameter.holstein_model, 1, 20)
     mps.canonicalise().normalize()
@@ -83,3 +84,11 @@ def test_site_entropy():
     assert np.allclose(entropy_bond[-2], entropy_2site[(mps.site_num-2, mps.site_num-1)])
     assert np.allclose(entropy_mutual[0,1],
             (entropy_1site[0]+entropy_1site[1]-entropy_2site[(0,1)])/2)
+
+
+def test_load_from_dense_wfn():
+    model = Model(basis=[BasisSimpleElectron(i) for i in range(5)], ham_terms=[])
+    ref_mps = Mps.random(model, 1, 20)
+    dense_wfn = ref_mps.todense()
+    loaded_mps = Mps.from_dense(model, dense_wfn)
+    assert np.allclose(dense_wfn, loaded_mps.todense())

--- a/renormalizer/utils/tests/test_quantity.py
+++ b/renormalizer/utils/tests/test_quantity.py
@@ -7,5 +7,5 @@ from renormalizer.utils import Quantity
 def test_quantity():
     q1 = Quantity(1, "a.u.")
     q2 = q1.as_unit("cm-1")
-    assert approx(q2.value, 2.1947e5)
-    assert approx(q2.as_au(), 1)
+    assert approx(q2.value, rel=1e-4) == 2.1947e5
+    assert approx(q2.as_au(), rel=1e-4) == 1


### PR DESCRIPTION
Add a classmethod for MPS that constructs MPS from dense wavefunction.

Also change `full_wfn` and `full_operator` to `todense` for clarity. `scipy.sparse` and `QUTIP` use the same interface