### PR TITLE
make dependency on primme optional

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
           command: cd doc; make html
 
       - persist_to_workspace:
-          root: docs/_build
+          root: doc/
           paths: html
 
   # ref: https://circleci.com/blog/deploying-documentation-to-github-pages-with-continuous-integration/
@@ -61,10 +61,10 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: docs/_build
+          at: doc/
       - run:
           name: Disable jekyll builds
-          command: touch docs/_build/html/.nojekyll
+          command: touch doc/html/.nojekyll
       - run:
           name: Install and configure dependencies
           command: |
@@ -76,7 +76,7 @@ jobs:
             - "94:05:b4:03:2a:1a:dd:ff:56:19:58:09:a1:51:bb:b1"
       - run:
           name: Deploy docs to gh-pages branch
-          command: gh-pages --dotfiles --message "[skip ci] Updates" --dist docs/_build/html
+          command: gh-pages --dotfiles --message "[skip ci] Updates" --dist doc/html
 
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,93 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+
+# Orbs are reusable packages of CircleCI configuration that you may share across projects, enabling you to create encapsulated, parameterized commands, jobs, and executors that can be used across multiple projects.
+# See: https://circleci.com/docs/2.0/orb-intro/
+orbs:
+  # The python orb contains a set of prepackaged CircleCI configuration you can use repeatedly in your configuration files
+  # Orb commands and jobs help you with common scripting around a language/tool
+  # so you dont have to copy and paste it everywhere.
+  # See the orb documentation here: https://circleci.com/developer/orbs/orb/circleci/python
+  python: circleci/python@1.5.0
+
+# Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
+jobs:
+  build-and-test: # This is the name oAch the steps below will be executed - below will use a python 3.10.2 container
+    # Change the version below to your required version of python
+    docker:
+      - image: cimg/python:3.8
+    # Checkout the code as the first step. This is a dedicated CircleCI step.
+    # The python orb's install-packages step will install the dependencies from a Pipfile via Pipenv by default.
+    # Here we're making sure we use just use the system-wide pip. By default it uses the project root's requirements.txt.
+    # Then run your tests!
+    # CircleCI will report the results back to your VCS provider.
+    steps:
+      - checkout
+      - run:
+          name: install openblas
+          command: |
+              sudo apt-get update
+              sudo apt-get -y install libblas-dev liblapack-dev
+      - python/install-packages:
+          pkg-manager: pip
+          # app-dir: ~/project/package-directory/  # If you're requirements.txt isn't in the root directory.
+          # pip-dependency-file: test-requirements.txt  # if you have a different name for your requirements file, maybe one that combines your runtime and test requirements.
+      - run:
+          name: Run tests
+          # This assumes pytest is installed via the install-package step above
+          command: |
+              pytest --durations=0
+              pip install primme==3.2.*
+              pytest --durations=0 renormalizer/mps/tests/test_gs.py::test_multistate
+      - run:
+          name: Run examples
+          command: |
+              cd example; bash run.sh
+              cd ..
+      - run:
+          name: Build docs
+          command: cd doc; make html
+
+      - persist_to_workspace:
+          root: docs/_build
+          paths: html
+
+  # ref: https://circleci.com/blog/deploying-documentation-to-github-pages-with-continuous-integration/
+  docs-deploy:
+    docker:
+      - image: node:8.10.0
+    steps:
+      - checkout
+      - attach_workspace:
+          at: docs/_build
+      - run:
+          name: Disable jekyll builds
+          command: touch docs/_build/html/.nojekyll
+      - run:
+          name: Install and configure dependencies
+          command: |
+            npm install -g --silent gh-pages@2.0.1
+            git config user.email "liwt31@163.com"
+            git config user.name "liwt31"
+      - add_ssh_keys:
+          fingerprints:
+            - "94:05:b4:03:2a:1a:dd:ff:56:19:58:09:a1:51:bb:b1"
+      - run:
+          name: Deploy docs to gh-pages branch
+          command: gh-pages --dotfiles --message "[skip ci] Updates" --dist docs/_build/html
+
+# Invoke jobs via workflows
+# See: https://circleci.com/docs/2.0/configuration-reference/#workflows
+workflows:
+  test: # This is the name of the workflow, feel free to change it to better match your workflow.
+    # Inside the workflow, you define the jobs you want to run.
+    jobs:
+      - build-and-test
+      - docs-deploy:
+          requires:
+            - build-and-test
+          filters:
+            branches:
+              only: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,20 @@
 language: python
 
 python:
-    - "3.6"
-    - "3.7"
+  - "3.7"
 
 before_install:
-    - sudo apt-get -y install libblas-dev liblapack-dev
+  - sudo apt-get -y install libblas-dev liblapack-dev
 
-install:
-    - pip install -r requirements.txt
+jobs:
+  include:
+    - name: default
+      install:
+        - pip install -r requirements.txt
+    - name: with primme
+      install:
+        - pip install -r requirements.txt
+        - pip install primme==3.2.*
 
 script:
     - pytest --durations=0

--- a/renormalizer/mps/backend.py
+++ b/renormalizer/mps/backend.py
@@ -9,6 +9,13 @@ import numpy as np
 
 from renormalizer.utils.utils import sizeof_fmt
 
+try:
+    import primme
+    IMPORT_PRIMME_EXCEPTION = None
+except Exception as e:
+    primme = None
+    IMPORT_PRIMME_EXCEPTION = e
+
 
 logger = logging.getLogger(__name__)
 

--- a/renormalizer/mps/gs.py
+++ b/renormalizer/mps/gs.py
@@ -12,10 +12,9 @@ import logging
 import numpy as np
 import scipy
 import opt_einsum as oe
-import primme
 
 from renormalizer.lib import davidson
-from renormalizer.mps.backend import xp, OE_BACKEND
+from renormalizer.mps.backend import xp, OE_BACKEND, primme, IMPORT_PRIMME_EXCEPTION
 from renormalizer.mps.matrix import multi_tensor_contract, tensordot, asnumpy, asxp
 from renormalizer.mps.hop_expr import  hop_expr
 from renormalizer.mps import Mpo, Mps
@@ -458,6 +457,9 @@ def eigh_iterative(
     #    e, c = scipy.sparse.linalg.lobpcg(A, np.array(cguess).T,
     #            M=M, largest=False)
     elif algo == "primme":
+        if primme is None:
+            logger.error("can not import primme")
+            raise IMPORT_PRIMME_EXCEPTION
         h_dim = np.sum(qnmat == mps.qntot)
         precond = lambda x: scipy.sparse.diags(1 / (hdiag + 1e-4)) @ x
         A = scipy.sparse.linalg.LinearOperator((h_dim, h_dim), matvec=hop, matmat=hop)

--- a/renormalizer/mps/mp.py
+++ b/renormalizer/mps/mp.py
@@ -659,11 +659,11 @@ class MatrixProduct:
                 elif ofs is OFS.ofs_ds:
                     if loss1 < 1e-10 and loss2 < 1e-10:
                         # at the end of the chain
-                        should_retain = entropy1 < entropy2
+                        should_retain = entropy1 <= entropy2
                     else:
                         should_retain = loss1 <= loss2
                 elif ofs is OFS.ofs_s:
-                    should_retain = entropy1 < entropy2
+                    should_retain = entropy1 <= entropy2
                 else:
                     assert ofs is  OFS.ofs_debug
                     should_retain = True

--- a/renormalizer/mps/tests/test_gs.py
+++ b/renormalizer/mps/tests/test_gs.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 from renormalizer.model import Model, h_qc
+from renormalizer.mps.backend import primme
 from renormalizer.mps.gs import construct_mps_mpo, optimize_mps
 from renormalizer.mps import Mpo, Mps
 from renormalizer.tests.parameter import holstein_model
@@ -42,7 +43,7 @@ def test_optimization(scheme, method):
 ))
 @pytest.mark.parametrize("algo", (
         "davidson",
-        "primme",
+        pytest.param("primme", marks=pytest.mark.skipif(primme is None, reason="primme not installed"))
 ))
 def test_multistate(method, algo):
     mps, mpo = construct_mps_mpo(holstein_model, procedure[0][0], nexciton)

--- a/renormalizer/mps/tests/test_mpo.py
+++ b/renormalizer/mps/tests/test_mpo.py
@@ -57,7 +57,7 @@ def test_swap_symbolic_mpo(nsites, nterms):
     basis = [BasisHalfSpin(i) for i in range(nsites)]
     model = Model(basis, ham_terms)
     mpo = Mpo(model)
-    for i in range(100):
+    for i in range(20):
         isite1 = max(int(random.random() * nsites) - 1, 0)
         isite2 = isite1 + 1
         basis = basis.copy()

--- a/renormalizer/mps/tests/test_tda.py
+++ b/renormalizer/mps/tests/test_tda.py
@@ -101,7 +101,7 @@ def test_tda():
     mps.optimize_config.nroots = 1
     energies, mps = gs.optimize_mps(mps, mpo)
     logger.info(f"M: {M}, energy : {np.array(energies[-1])*au2cm}")
-    tda = TDA(model, mpo, mps, nroots=3, algo="primme")
+    tda = TDA(model, mpo, mps, nroots=3)
     e = tda.kernel(include_psi0=False) 
     logger.info(f"tda energy : {(e-energies[-1])*au2cm}")
     assert np.allclose((e-energies[-1])*au2cm, [824.74925026, 936.42650242, 951.96826289], atol=1)

--- a/renormalizer/utils/configs.py
+++ b/renormalizer/utils/configs.py
@@ -309,6 +309,7 @@ class OptimizeConfig:
         self.method = "2site"
         # algo: arpack(Implicitly Restarted Lanczos Method)
         #       davidson(pyscf/davidson)
+        #       primme (if installed)
         self.algo = "davidson"
         self.nroots = 1
         # the ground state energy convergence tolerance

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,4 @@ PyYAML==5.4.*
 recommonmark==0.7.*
 sphinx_rtd_theme==0.5.*
 opt_einsum==3.3.*
-primme==3.2.*
 qutip==4.6.*


### PR DESCRIPTION
New users of renormalizer often struggle to install primme, which is not frequently used. In this PR I make the dependency on `primme` optional. It is removed from `requiements.txt`. But if it is correctly installed, renormalizer still supports the package. The Travis CI test configurations are updated such that two different sets of tests are run. The first is without `primme` (default) and the second is with `primme`. 

Also fix a small bug in OFS.