### PR TITLE
fix ci bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,10 @@ jobs:
             git config user.name "liwt31"
       - add_ssh_keys:
           fingerprints:
-            - "e6:24:b4:ab:d5:82:2b:6a:b5:a9:17:71:99:6d:0f:53"
+            - "2e:92:a5:a4:4f:ef:4a:97:19:91:7b:f2:52:43:fe:45"
+      - run:
+          name: clear outdated ssh key
+          command: ssh-add -D
       - run:
           name: Deploy docs to gh-pages branch
           command: gh-pages --dotfiles --message "[skip ci] Updates" --dist doc/html


### PR DESCRIPTION
- ssh should not be SHA1 (https://stackoverflow.com/questions/71500791/eclipse-git-youre-using-an-rsa-key-with-sha-1-which-is-no-longer-allowed-pl)
- ssh-add -D magic (https://stackoverflow.com/questions/33467474/github-authenticates-but-will-not-allow-code-push)
Hopefully works