### PR TITLE
Change import behavior

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,9 @@ jobs:
           name: Run tests
           # This assumes pytest is installed via the install-package step above
           command: |
-              pytest --durations=0
+              pip install pytest-xdist
+              export RENO_NUM_THREADS=1
+              pytest -n 4 --durations=0
               pip install primme==3.2.*
               pytest --durations=0 renormalizer/mps/tests/test_gs.py::test_multistate
       - run:

--- a/renormalizer/__init__.py
+++ b/renormalizer/__init__.py
@@ -2,20 +2,22 @@
 # Author: Jiajun Ren <jiajunren0522@gmail.com>
 import os
 import sys
+import warnings
 
-if "numpy" in sys.modules:
-    raise ImportError("renormalizer should be imported before numpy is imported")
 
-# set environment variables to limit NumPy cpu usage
-# Note that this should be done before NumPy is imported
-for env in ["MKL_NUM_THREADS", "NUMEXPR_NUM_THREADS", "OMP_NUM_THREADS"]:
-    os.environ[env] = "1"
-    del env
+reno_num_threads = os.environ.get("RENO_NUM_THREADS")
+if reno_num_threads is not None:
+    # set environment variables to limit NumPy cpu usage
+    # Note that this should be done before NumPy is imported
 
-# NEP-18 not working. For compatibility of newer NumPy version. See gh-cupy/cupy#2130
-os.environ["NUMPY_EXPERIMENTAL_ARRAY_FUNCTION"] = "0"
+    if "numpy" in sys.modules:
+        warnings.warn("renormalizer should be imported before numpy for `RENO_NUM_THREADS` to take effect")
+    else:
+        for env in ["MKL_NUM_THREADS", "NUMEXPR_NUM_THREADS", "OMP_NUM_THREADS"]:
+            os.environ[env] = reno_num_threads
+            del env
 
-del os, sys
+del os, sys, warnings
 
 from renormalizer.utils.log import init_log
 

--- a/renormalizer/mps/backend.py
+++ b/renormalizer/mps/backend.py
@@ -67,8 +67,10 @@ class Backend:
         self.first_mp = False
         self._real_dtype = None
         self._complex_dtype = None
-        #self.use_32bits()
-        self.use_64bits()
+        if os.environ.get("RENO_FP32") is None:
+            self.use_64bits()
+        else:
+            self.use_32bits()
 
     def free_all_blocks(self):
         if not USE_GPU:
@@ -129,6 +131,13 @@ class Backend:
     @dtypes.setter
     def dtypes(self, target):
         self.real_dtype, self.complex_dtype = target
+
+    @property
+    def canonical_atol(self):
+        if self.is_32bits:
+            return 1e-4
+        else:
+            return 1e-5
 
 
 backend = Backend()

--- a/renormalizer/mps/matrix.py
+++ b/renormalizer/mps/matrix.py
@@ -90,21 +90,25 @@ class Matrix:
     def l_combine(self):
         return self.reshape(self.l_combine_shape)
 
-    def check_lortho(self, rtol=1e-5, atol=1e-8):
+    def check_lortho(self, atol=None):
         """
         check L-orthogonal
         """
+        if atol is None:
+            atol = backend.canonical_atol
         tensm = asxp(self.array.reshape([np.prod(self.shape[:-1]), self.shape[-1]]))
         s = tensm.T.conj() @ tensm
-        return xp.allclose(s, xp.eye(s.shape[0]), rtol=rtol, atol=atol)
+        return xp.allclose(s, xp.eye(s.shape[0]), atol=atol)
 
-    def check_rortho(self, rtol=1e-5, atol=1e-8):
+    def check_rortho(self, atol=None):
         """
         check R-orthogonal
         """
+        if atol is None:
+            atol = backend.canonical_atol
         tensm = asxp(self.array.reshape([self.shape[0], np.prod(self.shape[1:])]))
         s = tensm @ tensm.T.conj()
-        return xp.allclose(s, xp.eye(s.shape[0]), rtol=rtol, atol=atol)
+        return xp.allclose(s, xp.eye(s.shape[0]), atol=atol)
 
     def to_complex(self):
         # `xp.array` always creates new array, so to_complex means copy, which is

--- a/renormalizer/mps/svd_qn.py
+++ b/renormalizer/mps/svd_qn.py
@@ -4,7 +4,7 @@ import logging
 
 import scipy.linalg
 
-from renormalizer.mps.backend import np
+from renormalizer.mps.backend import np, backend
 
 logger = logging.getLogger(__name__)
 
@@ -53,13 +53,13 @@ def add_orthonormal_basis(u):
     # add `n` basis. `n` is empirical
     m, n = u.shape
     assert 2 * n < m
-    assert np.allclose(u.T.conj() @ u, np.eye(n))
+    assert np.allclose(u.T.conj() @ u, np.eye(n), atol=backend.canonical_atol)
     a = np.random.rand(m,n)
     a = a - u @ (u.T.conj() @ a)
     q, _ = scipy.linalg.qr(a, mode='economic')
     res = np.concatenate([u, q], axis=1)
 
-    assert np.allclose(res.T.conj() @ res, np.eye(2 * n))
+    assert np.allclose(res.T.conj() @ res, np.eye(2 * n), atol=backend.canonical_atol)
     return res
 
 

--- a/renormalizer/transport/tests/test_kubo.py
+++ b/renormalizer/transport/tests/test_kubo.py
@@ -7,6 +7,7 @@ import qutip
 from renormalizer.model import Phonon, Mol, HolsteinModel, Model
 from renormalizer.model.basis import BasisSimpleElectron, BasisSHO
 from renormalizer.model.op import Op
+from renormalizer.mps.backend import backend
 from renormalizer.transport.kubo import TransportKubo
 from renormalizer.utils import Quantity, CompressConfig, EvolveConfig, EvolveMethod, CompressCriteria
 from renormalizer.utils.qutip_utils import get_clist, get_blist, get_holstein_hamiltonian, get_qnidx, \
@@ -58,6 +59,8 @@ def get_qutip_holstein_kubo(model, temperature, time_series):
 
 
 def test_peierls_kubo():
+    if backend.is_32bits:
+        pytest.skip("VMF too stiff for 32 bit float point operation")
     # number of mol
     n = 4
     # electronic coupling

--- a/renormalizer/utils/log.py
+++ b/renormalizer/utils/log.py
@@ -7,21 +7,19 @@ from logging import ERROR, WARN, INFO, DEBUG
 
 import numpy as np
 
-root_logger = logging.root
+package_logger = logging.getLogger("renormalizer")
 default_stream_handler = logging.StreamHandler()
 default_formatter = logging.Formatter("%(asctime)s[%(levelname)s] %(message)s")
 
 
 def init_log(level=logging.DEBUG):
-    root_logger.setLevel(level)
+    package_logger.setLevel(level)
 
     default_stream_handler.setLevel(logging.DEBUG)
 
     default_stream_handler.setFormatter(default_formatter)
 
-    default_stream_handler.addFilter(logging.Filter("renormalizer"))
-
-    root_logger.addHandler(default_stream_handler)
+    package_logger.addHandler(default_stream_handler)
 
 
 def set_stream_level(level):
@@ -29,8 +27,8 @@ def set_stream_level(level):
 
 
 def disable_stream_output():
-    if default_stream_handler in root_logger.handlers:
-        root_logger.removeHandler(default_stream_handler)
+    if default_stream_handler in package_logger.handlers:
+        package_logger.removeHandler(default_stream_handler)
 
 
 def register_file_output(file_path, mode="w", level=DEBUG):
@@ -38,7 +36,7 @@ def register_file_output(file_path, mode="w", level=DEBUG):
     file_handler.setLevel(level)
     file_handler.setFormatter(default_formatter)
     file_handler.addFilter(logging.Filter("renormalizer"))
-    root_logger.addHandler(file_handler)
+    package_logger.addHandler(file_handler)
 
 
 NP_ERRCONFIG = {"divide": "raise", "over": "raise", "under": "warn", "invalid": "raise"}

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ req = ["numpy",
 
 setuptools.setup(
     name="renormalizer",
-    version="0.0.3",
+    version="0.0.4",
     packages=setuptools.find_packages(),
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
- Make Renormalizer easier to use for other projects when imported as one of the many packages.
    - Renormalizer by default will not set the number of threads for NumPy. This is something to remind the group members and write into the document. Accordingly, change the NumPy import error into a warning
    - Change the logger behavior. Avoid using root logger.
- Add better support for 32-bit backend. Make some of the tests that originally can not pass or very time-consuming in 32-bit backend work for 32-bit backend.
- Optimize performance in circle CI by parrallel pytest. Now the whole tests take less than 6 min. 