### PR TITLE
Fix OpSum bug

### DIFF
--- a/renormalizer/model/op.py
+++ b/renormalizer/model/op.py
@@ -386,3 +386,6 @@ class OpSum(list):
         if isinstance(other, (int, float, complex, np.generic)):
             return self * other
         return OpSum(super().__rmul__(other))
+
+    # prevents NumPy universal function call
+    __array_ufunc__ = None


### PR DESCRIPTION
Overriding `__rmul__` of `list` has an interesting side effect
```
import numpy as np
a = np.float64(1)

# raises an error, as expected
b = a * [1, 2]

class MyList(list): pass
# also an error
b = a * MyList([1, 2])

class MyList(list):
    def __rmul__(self, other):
        print("rmul")
        return super().__rmul__(other)
# c is a numpy array, and "rmul" is not printed
c = a * MyList([1, 2])
```

In the `OpSum` class, we expect the multiplied result to be `OpSum` rather than `np.ndarray`, so override `__array_ufunc__` to prevent the behavior.