### PR TITLE
Add support for multiple quntum numbers

### DIFF
--- a/example/h2o_qc.py
+++ b/example/h2o_qc.py
@@ -22,11 +22,11 @@ if __name__ == "__main__":
     job_name = "qc"  #########
     log.set_stream_level(logging.DEBUG)
     log.register_file_output(dump_dir+job_name+".log", mode="w")
-    logger = logging.getLogger(__name__)
+    logger = logging.getLogger("renormalizer")
 
     spatial_norbs = 7
     spin_norbs = spatial_norbs * 2
-    h1e, h2e, nuc = h_qc.read_fcidump("h2o_fcidump.txt", spatial_norbs) 
+    h1e, h2e, nuc = h_qc.read_fcidump("h2o_fcidump.txt", spatial_norbs)
 
     # Potential for H2O has high symmetry and constructed MPO is smaller
     # than MPO in normal case. Use random potential to compare with normal MPO.
@@ -43,7 +43,7 @@ if __name__ == "__main__":
     mpo = Mpo(model)
     logger.info(f"mpo_bond_dims:{mpo.bond_dims}")
 
-    nelec = 10
+    nelec = [5, 5]
     energy_list = {}
     M = 50
     procedure = [[M, 0.4], [M, 0.2], [M, 0.1], [M, 0], [M, 0], [M,0], [M,0]]

--- a/renormalizer/cv/tests/test_H_chain.py
+++ b/renormalizer/cv/tests/test_H_chain.py
@@ -16,7 +16,6 @@ def test_H_chain_LDOS():
     # example to use Mollist2 to do CV calculation
 
     spatial_norbs = 4
-    spin_norbs = spatial_norbs * 2
     h1e, h2e, nuc = h_qc.read_fcidump(os.path.join(cur_dir,
         "fcidump_lowdin_h4.txt"), spatial_norbs) 
 
@@ -25,7 +24,7 @@ def test_H_chain_LDOS():
     model = Model(basis, ham_terms)
     mpo = Mpo(model)
     
-    nelec = spatial_norbs
+    nelec = [spatial_norbs//2, spatial_norbs//2]
     M = 50
     procedure = [[M, 0.4], [M, 0.2]] + [[M, 0],]*6
     mps = Mps.random(model, nelec, M, percent=1.0)
@@ -41,10 +40,10 @@ def test_H_chain_LDOS():
     def photoelectron_operator(idx):
         # norbs is the spin orbitals
         # green function
-        op_list = [Op("sigma_z", iorb, qn=0) for iorb in range(idx)]
-        return Op.product(op_list + [Op("sigma_+", idx, qn=-1)])
+        op_list = [Op("sigma_z", iorb, qn=[[0, 0]]) for iorb in range(idx)]
+        return Op.product(op_list + [Op("sigma_+", idx, qn=[[0, -1]])]) # always beta
 
-    dipole_model = photoelectron_operator(nelec-1)
+    dipole_model = photoelectron_operator(sum(nelec)-1)
     dipole_op = Mpo(model, dipole_model)
     b_mps = dipole_op.apply(mps)
 

--- a/renormalizer/model/basis.py
+++ b/renormalizer/model/basis.py
@@ -46,8 +46,14 @@ class BasisSet:
             self.sigmaqn.append(np.array(qn))
         self.sigmaqn:np.ndarray = np.array(self.sigmaqn)
 
+    def __str__(self):
+        ret = f"dof: {self.dof}, nbas: {self.nbas}"
+        if not np.all(self.sigmaqn == 0):
+            ret = ret + f", qn: {self.sigmaqn.tolist()}"
+        return f"{self.__class__.__name__}({ret})"
+
     def __repr__(self):
-        return f"(dof: {self.dof}, nbas: {self.nbas}, qn: {self.sigmaqn})"
+        return str(self)
 
     def op_mat(self, op: Op):
         """
@@ -135,8 +141,8 @@ class BasisSHO(BasisSet):
             self.dvr_x, self.dvr_v = scipy.linalg.eigh(self.op_mat("x"))
             self.dvr = True
 
-    def __repr__(self):
-        return f"(dof: {self.dof}, x0: {self.x0}, omega: {self.omega}, nbas: {self.nbas})"
+    def __str__(self):
+        return f"BasisSHO(dof: {self.dof}, x0: {self.x0}, omega: {self.omega}, nbas: {self.nbas})"
 
     def op_mat(self, op: Union[Op, str]):
         if not isinstance(op, Op):
@@ -424,8 +430,8 @@ class BasisSineDVR(BasisSet):
         self.dvr_v = np.sqrt(2/(nbas+1)) * \
             np.sin(np.tensordot(tmp, tmp, axes=0)*np.pi/(nbas+1))
 
-    def __repr__(self):
-        return f"(xi: {self.xi}, xf: {self.xf}, nbas: {self.nbas})"
+    def __str__(self):
+        return f"BasisSineDVR(xi: {self.xi}, xf: {self.xf}, nbas: {self.nbas})"
 
     def op_mat(self, op: Union[Op, str]):
         if not isinstance(op, Op):
@@ -820,6 +826,14 @@ class BasisSimpleElectron(BasisSet):
     dof : any hashable object
         The name of the DoF contained in the basis set.
 
+    Examples
+    --------
+    >>> b = BasisSimpleElectron(0)
+    >>> b
+    BasisSimpleElectron(dof: 0, nbas: 2, qn: [[0], [1]])
+    >>> b.op_mat(r"a^\dagger")
+    array([[0., 0.],
+           [1., 0.]])
     """
     is_electron = True
 
@@ -864,6 +878,8 @@ class BasisHalfSpin(BasisSet):
     Examples
     --------
     >>> b = BasisHalfSpin(0)
+    >>> b
+    BasisHalfSpin(dof: 0, nbas: 2)
     >>> b.op_mat("X")
     array([[0., 1.],
            [1., 0.]])

--- a/renormalizer/model/basis.py
+++ b/renormalizer/model/basis.py
@@ -20,7 +20,7 @@ class BasisSet:
             For basis containing multiple DoFs, the type should be a ``list`` or ``tuple``
             of anything that can be hashed.
         nbas (int): number of dimension of the basis set
-        sigmaqn (List(int)): the qn of each basis
+        sigmaqn (List): the quantum number of each basis. Could be an integer or tuple of integers
 
     """
 
@@ -33,15 +33,18 @@ class BasisSet:
     #: If the basis set contains multiple DoFs.
     multi_dof = False
 
-    def __init__(self, dof, nbas: int, sigmaqn: List[int]):
+    def __init__(self, dof, nbas: int, sigmaqn: List):
         self.dof = dof
 
         assert type(nbas) is int
         self.nbas = nbas
 
+        self.sigmaqn = []
         for qn in sigmaqn:
-            assert type(qn) is int
-        self.sigmaqn = sigmaqn
+            if isinstance(qn, int):
+                qn = [qn]
+            self.sigmaqn.append(np.array(qn))
+        self.sigmaqn:np.ndarray = np.array(self.sigmaqn)
 
     def __repr__(self):
         return f"(dof: {self.dof}, nbas: {self.nbas}, qn: {self.sigmaqn})"
@@ -333,7 +336,7 @@ class BasisHopsBoson(BasisSet):
     dof :
         The name of the DoF contained in the basis set. The type could be anything that can be hashed.
     nbas : int
-        number of dimension of the basis set (highest occupation number)
+        number of dimension of the basis set (the highest occupation number)
 
     """
 
@@ -689,16 +692,16 @@ class BasisMultiElectron(BasisSet):
     ----------
     dof : a :class:`list` or :class:`tuple` of hashable objects.
         The names of the DoFs contained in the basis set.
-    sigmaqn : :class:`list` of :class:`int`
-        The sigmaqn of each basis
+    sigmaqn : :class:`list` of :class:`int` or :class:`list` of containers of :class:`int`
+        The quantum number of each basis
     """
 
     is_electron = True
     multi_dof = True
 
-    def __init__(self, dof, sigmaqn: List[int]):
+    def __init__(self, dof, sigmaqn: List):
 
-        assert len(sigmaqn) == len(sigmaqn)
+        assert len(dof) == len(sigmaqn)
         self.dof_name_map = {name: i for i, name in enumerate(dof)}
         super().__init__(dof, len(dof), sigmaqn)
 
@@ -806,6 +809,7 @@ class BasisMultiElectronVac(BasisSet):
     def copy(self, new_dof):
         return self.__class__(new_dof)
 
+
 class BasisSimpleElectron(BasisSet):
 
     r"""
@@ -852,8 +856,10 @@ class BasisHalfSpin(BasisSet):
 
     Parameters
     ----------
-    dof : any hashable object
+    dof : any hashable object such as integer
         The name of the DoF contained in the basis set.
+    sigmaqn : :class:`list` of :class:`int` or :class:`list` of containers of :class:`int`
+        The quantum number of each basis
 
     Examples
     --------
@@ -868,7 +874,7 @@ class BasisHalfSpin(BasisSet):
 
     is_spin = True
 
-    def __init__(self, dof, sigmaqn:List[int]=None):
+    def __init__(self, dof, sigmaqn:List=None):
         if sigmaqn is None:
             sigmaqn = [0, 0]
         super().__init__(dof, 2, sigmaqn)

--- a/renormalizer/model/model.py
+++ b/renormalizer/model/model.py
@@ -44,6 +44,10 @@ class Model:
         if len(all_dof_list) != len(set(all_dof_list)):
             raise ValueError("Duplicate DoF definition found in the basis list.")
         self.basis: List[BasisSet] = basis
+        qn_size_list = [b.sigmaqn.shape[1] for b in basis]
+        if len(set(qn_size_list)) != 1:
+            raise ValueError(f"Inconsistent quantum number size: {set(qn_size_list)}")
+        self.qn_size: int = qn_size_list[0]
         if output_ordering is None:
             self.output_ordering = self.basis
         else:

--- a/renormalizer/model/op.py
+++ b/renormalizer/model/op.py
@@ -395,7 +395,18 @@ class OpSum(list):
     []
     >>> opsum * opsum
     [Op('X X', [0, 0], 1.0), Op('X Y', [0, 1], 2.0), Op('Y X', [1, 0], 2.0), Op('Y Y', [1, 1], 4.0)]
+    >>> OpSum.product([opsum, opsum])
+    [Op('X X', [0, 0], 1.0), Op('X Y', [0, 1], 2.0), Op('Y X', [1, 0], 2.0), Op('Y Y', [1, 1], 4.0)]
     """
+    @classmethod
+    def product(cls, op_list):
+        if len(op_list) == 0:
+            return cls()
+        prod = op_list[0]
+        for op in op_list[1:]:
+            prod = prod * op
+        return prod
+
     def copy(self):
         return OpSum(super().copy())
 

--- a/renormalizer/model/op.py
+++ b/renormalizer/model/op.py
@@ -158,6 +158,7 @@ class Op:
                 raise ValueError("qn should be a list.")
 
         # handle default qn when qn_list is None
+        # "a^\dagger" and "a" are taken to be 1 and -1 respectively
         if qn_list is None:
             qn_list = []
             for s in self.split_symbol:

--- a/renormalizer/model/op.py
+++ b/renormalizer/model/op.py
@@ -32,11 +32,14 @@ class Op:
         in which case every symbol is assumed to share the same DoF name.
     factor : :class:`float` or :class:`complex` or :class:`Quantity`
         The prefactor of the operator.
-    qn : :class:`int` or :class:`list` of :class:`int`.
+    qn : :class:`int` or :class:`list` of :class:`int` or :class:`list` of containers of :class:`int`.
         The quantum number of the symbol. For simple symbol the ``qn`` should be an :class:`int`.
         For complex symbol quantum number of each simple symbol contained in the complex symbol
-        should be provided. If ``qn`` is set to `None`, then the quantum number for every symbol is set to 0
+        should be provided in a :class:`list`.
+        If ``qn`` is set to `None`, then the quantum number for every symbol is set to 0
         except for``"a^\dagger"`` and ``"a"``, whose quantum number are set to 1 and -1 respectively.
+        For multiple quantum numbers :class:`list` of containers of :class:`int`
+        should be provided without any abbreviation.
 
     Notes
     -----
@@ -54,7 +57,7 @@ class Op:
     --------
     >>> from renormalizer.model import Op
     >>> Op(r"a^\dagger a", ['site0', "site1"], 2., qn=[1, -1])
-    Op('a^\\dagger a', ['site0', 'site1'], 2.0, [1, -1])
+    Op('a^\\dagger a', ['site0', 'site1'], 2.0, [[1], [-1]])
     >>> x = Op("X", 0, 0.5)
     >>> 3 * x
     Op('X', [0], 1.5)
@@ -94,14 +97,16 @@ class Op:
         return Op(symbol, dof_name, factor, qn)
 
     @classmethod
-    def identity(cls, dof):
+    def identity(cls, dof, qn_size=1):
         """
         Construct identity operator.
         """
         if isinstance(dof, list):
-            return cls(" ".join(["I"] * len(dof)), dof)
+            qn = [np.zeros(qn_size, dtype=int)] * len(dof)
+            return cls(" ".join(["I"] * len(dof)), dof, qn=qn)
         else:
-            return cls("I", dof)
+            qn = [np.zeros(qn_size, dtype=int)]
+            return cls("I", dof, qn=qn)
 
     def __init__(self, symbol: str, dof, factor: Union[float, Quantity] = 1.0, qn: Union[List, int] = None):
         # This is one of the most external user interface, so detailed argument checking is necessary
@@ -123,8 +128,11 @@ class Op:
                 dofs = [dof]
             # same for qn
             if isinstance(qn, list):
-                assert len(qn) == 1
+                if len(qn) != 1:
+                    raise ValueError(f"Incompatible sizes of quantum number {qn} and symbol {self.split_symbol}")
                 qn_list = qn
+            elif qn is None:
+                qn_list = None
             else:
                 qn_list = [qn]
         # complex symbol
@@ -144,17 +152,25 @@ class Op:
                 qn_list = qn
             # the default value
             elif qn is None:
-                qn_list = [None] * num_simple_symbol
+                qn_list = None
             # Can't assume the same qn as Dof name above
             else:
                 raise ValueError("qn should be a list.")
 
+        # handle default qn when qn_list is None
+        if qn_list is None:
+            qn_list = []
+            for s in self.split_symbol:
+                if s == r"a^\dagger":
+                    qn_list.append(1)
+                elif s == "a":
+                    qn_list.append(-1)
+                else:
+                    qn_list.append(0)
+
         for dof in dofs:
             if dof.__hash__ is None:
                 raise ValueError(f"dof name should be hashable. Got {dof}.")
-        for qn in qn_list:
-            if qn is not None and not isinstance(qn, int):
-                raise TypeError(f"qn for each symbol should be an integer. Got {qn_list}.")
 
         # argument checking done.
         assert len(dofs) == len(self.split_symbol)
@@ -163,7 +179,7 @@ class Op:
         if isinstance(factor, Quantity):
             factor = factor.as_au()
         self._factor: float = factor + 0.0 # convert to float. Note this works for complex number
-        self.qn_list: List[int] = qn_list
+        self.qn_list: List[np.ndarray] = [np.array(qn).reshape(-1) for qn in qn_list]
 
     def split_elementary(self, dof_to_siteidx) -> Tuple[List["Op"], Union[float, complex]]:
         """
@@ -210,21 +226,20 @@ class Op:
         return self._factor
 
     @property
-    def qn(self) -> int:
+    def qn(self) -> np.ndarray:
         r"""
         Total quantum number of the operator. Sum of ``self.qn_list``.
         Quantum number of ``"a^\dagger"`` and ``"a"`` is taken to be 1 and -1
         if not specified.
         """
-        # should be the most common case
-        if set(self.qn_list) == {None}:
-            return self.split_symbol.count(r"a^\dagger") - self.split_symbol.count("a")
-        # None and integer both in self._qn_list. Not good
-        elif None in set(self.qn_list):
-            raise ValueError(f"qn ill-defined in {self}")
-        # most general case
-        else:
-            return sum(self.qn_list)
+        return sum(self.qn_list)
+
+    @property
+    def qn_size(self) -> int:
+        """
+        Size of the quantum numbers
+        """
+        return len(self.qn)
 
     @property
     def is_identity(self) -> bool:
@@ -250,7 +265,7 @@ class Op:
         Op('X Y', [0, 2], 0.5)
         """
         if self.is_identity:
-            return self.__class__.identity(self.dofs[0])
+            return self.__class__.identity(self.dofs[0], qn_size=self.qn_size)
         new_symbol_list = []
         new_dof_list = []
         new_qn_list = []
@@ -300,7 +315,7 @@ class Op:
         op_tuple : tuple
             The converted tuple.
         """
-        return self.symbol, tuple(self.dofs), self.factor, tuple(self.qn_list)
+        return self.symbol, tuple(self.dofs), self.factor, tuple(tuple(t) for t in self.qn_list)
 
     def __hash__(self):
         return hash(self.to_tuple())
@@ -312,8 +327,8 @@ class Op:
 
     def __str__(self):
         ret =  ", ".join([repr(self.symbol), str(self.dofs), str(self.factor)])
-        if set(self.qn_list) != {None}:
-            ret = ret + f", {self.qn_list}"
+        if not np.all(np.array(self.qn_list) == 0):
+            ret = ret + f", {[qn.tolist() for qn in self.qn_list]}"
         return f"Op({ret})"
 
     def __repr__(self):

--- a/renormalizer/mps/tests/test_gs.py
+++ b/renormalizer/mps/tests/test_gs.py
@@ -99,6 +99,7 @@ def test_ofs():
     mpo = Mpo(mps_opt.model)
     assert mps_opt.expectation(mpo) == pytest.approx(GS_E, rel=1e-5)
 
+
 @pytest.mark.parametrize("with_ofs", (True, False))
 def test_qc(with_ofs):
     """
@@ -118,11 +119,11 @@ def test_qc(with_ofs):
 
     fci_e = -3.23747673055271 - nuc
 
-    nelec = 6
-    M = 20
+    nelec = [3, 3]
+    M = 24
     procedure = [[M, 0.4], [M, 0.2], [M, 0.1], [M, 0], [M, 0], [M, 0], [M, 0]]
     mps = Mps.random(model, nelec, M, percent=1.0)
-    hf = Mps.hartree_product_state(model, {i:1 for i in range(nelec)})
+    hf = Mps.hartree_product_state(model, {i:1 for i in range(sum(nelec))})
     mps = mps.scale(1e-8)+hf
     #print("hf energy", mps.expectation(mpo))
     mps.optimize_config.procedure = procedure

--- a/renormalizer/mps/tests/test_gs.py
+++ b/renormalizer/mps/tests/test_gs.py
@@ -120,8 +120,9 @@ def test_qc(with_ofs):
     fci_e = -3.23747673055271 - nuc
 
     nelec = [3, 3]
-    M = 24
+    M = 30
     procedure = [[M, 0.4], [M, 0.2], [M, 0.1], [M, 0], [M, 0], [M, 0], [M, 0]]
+    np.random.seed(2023)
     mps = Mps.random(model, nelec, M, percent=1.0)
     hf = Mps.hartree_product_state(model, {i:1 for i in range(sum(nelec))})
     mps = mps.scale(1e-8)+hf

--- a/renormalizer/mps/tests/test_mpo.py
+++ b/renormalizer/mps/tests/test_mpo.py
@@ -97,7 +97,7 @@ def test_offset(scheme):
 
 def test_identity():
     identity = Mpo.identity(holstein_model)
-    mps = Mps.random(holstein_model, nexciton=1, m_max=5)
+    mps = Mps.random(holstein_model, qntot=1, m_max=5)
     assert mps.expectation(identity) == pytest.approx(mps.mp_norm) == pytest.approx(1)
 
 

--- a/renormalizer/mps/tests/test_sbm.py
+++ b/renormalizer/mps/tests/test_sbm.py
@@ -25,7 +25,6 @@ def test_zt():
     mps = Mps.ground_state(model, False)
     mps.compress_config = CompressConfig(threshold=1e-6)
     mps.evolve_config = EvolveConfig(adaptive=True, guess_dt=0.1)
-    mps.use_dummy_qn = True
     mpo = Mpo(model)
     time_series = [0]
     spin = [1]

--- a/renormalizer/spectra/tests/test_spectra.py
+++ b/renormalizer/spectra/tests/test_spectra.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 # Author: Jiajun Ren <jiajunren0522@gmail.com>
-from __future__ import absolute_import, print_function, division
-
 import os
 
 import numpy as np


### PR DESCRIPTION
- Quantum numbers are internally represented as `np.ndarray`. If one quantum number is used and the bond dimension is two, the quantum number at one bond has the form `array([[0], [1]])`. The old form is `[0, 1]`. If two quantum numbers are used and the bond dimension is two, the quantum number at one bond has the form `array([[0, 1], [1, 0]])`. The conserved quantum number (`qntot`) is also represented as `np.ndarray`.
- To specify multiple quantum numbers, pass in a container of integers instead of an integer as quantum number arguments when constructing `BasisSet` and `Op`. The old interface for a single quantum number is not broken.
- The current code is only tested on ab initio Hamiltonian. Bugs for more general cases are expected but they should be easy to fix.

- The PR contains a backward-incompatible change: `nexciton` in function arguments is renamed to `qntot` for consistency.