### PR TITLE
Revert dependency version to match python 3.7

### DIFF
--- a/renormalizer/transport/tests/test_kubo.py
+++ b/renormalizer/transport/tests/test_kubo.py
@@ -55,7 +55,7 @@ def get_qutip_holstein_kubo(model, temperature, time_series):
     j_oper = sum(terms).extract_states(qn_idx)
 
     # Add the negative sign because j is taken to be real
-    return -qutip.correlation(H, init_state, [0], time_series, [], j_oper, j_oper)[0]
+    return -qutip.correlation_2op_2t(H, init_state, [0], time_series, [], j_oper, j_oper)[0]
 
 
 def test_peierls_kubo():
@@ -129,9 +129,9 @@ def get_qutip_peierls_kubo(J, nsites, ph_levels, omega, g, temperature, time_ser
     j_oper2 = sum(peierls_terms).extract_states(qn_idx)
 
     # Add negative signs because j is taken to be real
-    corr1 = -qutip.correlation(H, init_state, [0], time_series, [], j_oper1, j_oper1)[0]
-    corr2 = -qutip.correlation(H, init_state, [0], time_series, [], j_oper1, j_oper2)[0]
-    corr3 = -qutip.correlation(H, init_state, [0], time_series, [], j_oper2, j_oper1)[0]
-    corr4 = -qutip.correlation(H, init_state, [0], time_series, [], j_oper2, j_oper2)[0]
+    corr1 = -qutip.correlation_2op_2t(H, init_state, [0], time_series, [], j_oper1, j_oper1)[0]
+    corr2 = -qutip.correlation_2op_2t(H, init_state, [0], time_series, [], j_oper1, j_oper2)[0]
+    corr3 = -qutip.correlation_2op_2t(H, init_state, [0], time_series, [], j_oper2, j_oper1)[0]
+    corr4 = -qutip.correlation_2op_2t(H, init_state, [0], time_series, [], j_oper2, j_oper2)[0]
     corr = corr1 + corr2 + corr3 + corr4
     return corr, np.array([corr1, corr2, corr3, corr4]).T

--- a/renormalizer/transport/tests/test_spectral_function.py
+++ b/renormalizer/transport/tests/test_spectral_function.py
@@ -69,4 +69,4 @@ def get_qutip_holstein_sf(nsites, J, ph_levels, omega, g, temperature, time_seri
         init_state_list.append((-beta * (omega * b.dag() * b)).expm().unit())
     init_state = qutip.tensor(init_state_list)
 
-    return qutip.correlation(H, init_state, [0], time_series, [], clist[1], clist[0].dag())[0] / 1j
+    return qutip.correlation_2op_2t(H, init_state, [0], time_series, [], clist[1], clist[0].dag())[0] / 1j

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy==1.22.*
-scipy==1.8.*
+numpy==1.21.*
+scipy==1.7.*
 pytest==6.2.*
 h5py==3.1.*
 PyYAML==5.4.*


### PR DESCRIPTION
Remaining warnings of `pytest`:

```shell
..\..\..\anaconda3\envs\reno\lib\site-packages\qutip\__init__.py:128
  ...\qutip\__init__.py:128: UserWarning: matplotlib not found: Graphics will not work.
    warnings.warn("matplotlib not found: Graphics will not work.")

renormalizer/mps/tests/test_mp.py::test_save_load
  ...\numpy\lib\npyio.py:719: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
    val = np.asanyarray(val)
```

Tested on Windows 11 x86_64 with python=3.7, renormalizer=0.0.10.