### PR TITLE
mpo dump remove warnings and future errors

### DIFF
--- a/renormalizer/mps/mp.py
+++ b/renormalizer/mps/mp.py
@@ -1014,6 +1014,10 @@ class MatrixProduct:
             data_dict[attr] = getattr(self, attr)
             # qn is ragged array which will raise a VisibleDeprecationWarning
             # and convert it to np.object
+        qn = data_dict['qn']
+        arr = np.empty(len(qn), object)
+        arr[:] = qn
+        data_dict['qn'] = arr
         try:
             np.savez(fname, **data_dict)
         except Exception:


### PR DESCRIPTION
Starting from `numpy==1.24.0`, the occurrence of the `VisibleDeprecationWarning` when trying to save a list of lists with varying lengths has been rectified, resulting in a `ValueError` instead. So I made some changes here.