### PR TITLE
a trick but greatly accelerate h_qc construction.

### DIFF
--- a/renormalizer/model/h_qc.py
+++ b/renormalizer/model/h_qc.py
@@ -143,15 +143,16 @@ def qc_model(h1e, h2e, conserve_qn=True):
         return Op.product(new_ops)
 
     # 1-e terms
-    for p, q in itertools.product(range(norbs), repeat=2):
+    pairs = np.argwhere(h1e!=0)
+    for p, q in pairs:
         op = process_op(a_dag_ops[p] * a_ops[q])
         ham_terms.append(op * h1e[p, q])
 
     # 2-e terms.
-    for q,s in itertools.product(range(norbs),repeat = 2):
-        for p,r in itertools.product(range(q),range(s)):
-            op = process_op(Op.product([a_dag_ops[p], a_dag_ops[q], a_ops[r], a_ops[s]]))
-            ham_terms.append(op * h2e[p, q, r, s])
+    pairs = np.argwhere(h2e!=0)
+    for p, q, r, s in pairs:
+        op = process_op(Op.product([a_dag_ops[p], a_dag_ops[q], a_ops[r], a_ops[s]]))
+        ham_terms.append(op * h2e[p, q, r, s])
 
 
     basis = []


### PR DESCRIPTION
When constructing the qc mpo, simply discard useless loops which are very time consuming by picking only non-zero integrals.
Take the example of H-50 (100 spin orbitals), this trick speeds up thousands of times.