### PR TITLE
Enhance mps/mpo reproducibility; Print git hash for easier debugging;…

### DIFF
--- a/renormalizer/mps/backend.py
+++ b/renormalizer/mps/backend.py
@@ -3,6 +3,7 @@
 import os
 import logging
 import random
+import subprocess
 
 import numpy as np
 
@@ -49,6 +50,13 @@ def try_import_cupy():
     logger.info(f"Using GPU: {GPU_ID}")
     return True, cp
 
+def get_git_commit_hash():
+    try:
+        commit_hash = subprocess.check_output(['git', 'rev-parse', 'HEAD']).strip().decode('utf-8')
+        return commit_hash
+    except subprocess.CalledProcessError:
+        return "Unknown"
+
 
 USE_GPU, xp = try_import_cupy()
 
@@ -56,17 +64,25 @@ USE_GPU, xp = try_import_cupy()
 #USE_GPU = False
 #xp = np
 
+xpseed = 2019
+npseed = 9012
+randomseed = 1092
+
+xp.random.seed(xpseed)
+np.random.seed(npseed)
+random.seed(randomseed)
+
+
 if not USE_GPU:
     logger.info("Use NumPy as backend")
+    logger.info(f"numpy random seed is {npseed}")
     OE_BACKEND = "numpy"
 else:
     logger.info("Use CuPy as backend")
+    logger.info(f"cupy random seed is {xpseed}")
     OE_BACKEND = "cupy"
-
-
-xp.random.seed(2019)
-np.random.seed(9012)
-random.seed(1092)
+logger.info(f"random seed is {randomseed}")
+logger.info("Git Commit Hash: %s", get_git_commit_hash())
 
 
 class Backend:

--- a/renormalizer/mps/gs.py
+++ b/renormalizer/mps/gs.py
@@ -368,9 +368,11 @@ def sign_fix(c, nroots):
         if isinstance(c, list):
             return [ci / np.sign(ci[np.abs(ci).argmax()]) for ci in c]
         else:
-            return c / np.sign(np.max(np.abs(c), axis=0))
+            idx = np.abs(c).argmax(axis=0)
+            return c / np.sign(c[idx, range(c.shape[1])])
     else:
         return c / np.sign(c[np.abs(c).argmax()])
+
 
 def eigh_direct(
     mps: Mps,

--- a/renormalizer/mps/gs.py
+++ b/renormalizer/mps/gs.py
@@ -363,6 +363,15 @@ def get_ham_direct(
     return ham
 
 
+def sign_fix(c, nroots):
+    if nroots > 1:
+        if isinstance(c, list):
+            return [ci / np.sign(np.max(np.abs(ci))) for ci in c]
+        else:
+            return c / np.sign(np.max(c, axis=0))
+    else:
+        return c / np.sign(np.max(c))
+
 def eigh_direct(
     mps: Mps,
     qn_mask: np.ndarray,
@@ -383,11 +392,11 @@ def eigh_direct(
     nroots = mps.optimize_config.nroots
     if nroots == 1:
         e = w[0]
-        c = v[:, 0] / np.sign(np.max(v[:, 0]))
+        c = v[:, 0]
     else:
         e = w[:nroots]
-        c = [v[:, iroot] / np.sign(np.max(v[:, iroot])) for iroot in range(min(nroots, v.shape[1]))]
-    return e, c
+        c = [v[:, iroot] for iroot in range(min(nroots, v.shape[1]))]
+    return e, sign_fix(c, nroots)
 
 
 def get_ham_iterative(
@@ -556,7 +565,4 @@ def eigh_iterative(
     else:
         assert False
     logger.debug(f"use {algo}, HC hops: {count}")
-    if nroots == 1:
-        return e, c/np.sign(np.max(c))
-    else:
-        return e, c/np.sign(np.max(c, axis=0))
+    return e, sign_fix(c, nroots)

--- a/renormalizer/mps/gs.py
+++ b/renormalizer/mps/gs.py
@@ -383,10 +383,10 @@ def eigh_direct(
     nroots = mps.optimize_config.nroots
     if nroots == 1:
         e = w[0]
-        c = v[:, 0]
+        c = v[:, 0] / np.sign(np.max(v[:, 0]))
     else:
         e = w[:nroots]
-        c = [v[:, iroot] for iroot in range(min(nroots, v.shape[1]))]
+        c = [v[:, iroot] / np.sign(np.max(v[:, iroot])) for iroot in range(min(nroots, v.shape[1]))]
     return e, c
 
 
@@ -556,4 +556,7 @@ def eigh_iterative(
     else:
         assert False
     logger.debug(f"use {algo}, HC hops: {count}")
-    return e, c
+    if nroots == 1:
+        return e, c/np.sign(np.max(c))
+    else:
+        return e, c/np.sign(np.max(c, axis=0))

--- a/renormalizer/mps/gs.py
+++ b/renormalizer/mps/gs.py
@@ -366,11 +366,11 @@ def get_ham_direct(
 def sign_fix(c, nroots):
     if nroots > 1:
         if isinstance(c, list):
-            return [ci / np.sign(np.max(np.abs(ci))) for ci in c]
+            return [ci / np.sign(ci[np.abs(ci).argmax()]) for ci in c]
         else:
-            return c / np.sign(np.max(c, axis=0))
+            return c / np.sign(np.max(np.abs(c), axis=0))
     else:
-        return c / np.sign(np.max(c))
+        return c / np.sign(c[np.abs(c).argmax()])
 
 def eigh_direct(
     mps: Mps,

--- a/renormalizer/mps/mp.py
+++ b/renormalizer/mps/mp.py
@@ -49,7 +49,7 @@ class MatrixProduct:
 
         mp.qn = []
         for i in range(nsites+1):
-            subqn = npload[f"subqn_{i}"].astype(int).tolist()    
+            subqn = npload[f"subqn_{i}"].astype(int).tolist()
             mp.qn.append(subqn)
 
         mp.qnidx = int(npload["qnidx"])
@@ -1084,6 +1084,9 @@ class MatrixProduct:
         arr = np.empty(len(qn), object)
         arr[:] = qn
         data_dict['qn'] = arr
+
+        for i in range(self.site_num+1):
+            data_dict[f"subqn_{i}"] = qn[i]
         
         try:
             np.savez(fname, **data_dict)

--- a/renormalizer/mps/mpo.py
+++ b/renormalizer/mps/mpo.py
@@ -155,7 +155,7 @@ class Mpo(MatrixProduct):
 
     @classmethod
     def finiteT_cv(cls, model, nexciton, m_max, spectratype, percent=1.0):
-        np.random.seed(0)
+        # np.random.seed(0)
 
         X = cls()
         X.model = model

--- a/renormalizer/mps/symbolic_mpo.py
+++ b/renormalizer/mps/symbolic_mpo.py
@@ -140,6 +140,7 @@ def construct_symbolic_mpo(table, factor, algo="Hopcroft-Karp"):
     # unique operators with DoF names taken into consideration
     # The inclusion of DoF names is necessary for multi-dof basis.
     unique_op = OrderedDict.fromkeys(table.ravel())
+    # Convert Set(table.ravel()) to List will change the Op order in list, OrderedDict made reproducible
     unique_op = list(unique_op.keys())
     # check the index of different operators could be represented with np.uint16
     assert len(unique_op) < max_uint16

--- a/renormalizer/mps/symbolic_mpo.py
+++ b/renormalizer/mps/symbolic_mpo.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 import itertools
-from collections import namedtuple
+from collections import namedtuple, OrderedDict
 from typing import List, Set, Tuple, Dict
 
 import numpy as np
@@ -136,10 +136,11 @@ def construct_symbolic_mpo(table, factor, algo="Hopcroft-Karp"):
 
     # translate the symbolic operator table to an easy to manipulate numpy array
     table = np.array(table)
+
     # unique operators with DoF names taken into consideration
     # The inclusion of DoF names is necessary for multi-dof basis.
-    unique_op: Set[Op] = set(table.ravel())
-
+    unique_op = OrderedDict.fromkeys(table.ravel())
+    unique_op = list(unique_op.keys())
     # check the index of different operators could be represented with np.uint16
     assert len(unique_op) < max_uint16
 


### PR DESCRIPTION
- Enhance mps/mpo reproducibility; Currently, even with preset random seed, the MPO or the subsequent ground state MPS will be different for two runs. The MPO is different because the Op order can be different before doing Hopcroft-Corp; The MPS can be different because the sign carried by the eigenvectors.  This does not influence the final energy, but keeping everything reproducible could be important at sometime, especially for debugging purpose 
- The git hash information is printed every time running the package, for easier debugging
- Fix mp dump/load 