### PR TITLE
Correct numpy tolerence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.eps
 *.png
 *.lprof
+*.diff
 
 .idea/
 .cache/

--- a/renormalizer/mps/backend.py
+++ b/renormalizer/mps/backend.py
@@ -61,8 +61,8 @@ def get_git_commit_hash():
 USE_GPU, xp = try_import_cupy()
 
 
-#USE_GPU = False
-#xp = np
+# USE_GPU = False
+# xp = np
 
 xpseed = 2019
 npseed = 9012
@@ -166,10 +166,42 @@ class Backend:
 
     @property
     def canonical_atol(self):
-        if self.is_32bits:
-            return 1e-4
-        else:
-            return 1e-5
+        '''
+        Absolute tolerence for use in matrix.check_lortho, 
+        mp.check_left_canonical, mp.ensure_left_canonical
+        and their right counterparts
+        '''
+        return (
+            self._canonical_atol
+            if hasattr(self, "_canonical_atol")
+            else (1e-4 if self.is_32bits else 1e-8)
+        )
+
+    @property
+    def canonical_rtol(self):
+        '''
+        Relative tolerence for use in matrix.check_lortho, 
+        mp.check_left_canonical, mp.ensure_left_canonical
+        and their right counterparts
+        '''
+        return (
+            self._canonical_rtol
+            if hasattr(self, "_canonical_rtol")
+            else (1e-2 if self.is_32bits else 1e-5)
+        )
+
+    @canonical_atol.setter
+    def canonical_atol(self, value):
+        self._canonical_atol = self._tol_checker(value)
+
+    @canonical_rtol.setter
+    def canonical_rtol(self, value):
+        self._canonical_rtol = self._tol_checker(value)
+
+    def _tol_checker(self, value):
+        if not isinstance(value, (int, float)) or value < 0:
+            raise ValueError("Tolerance must be a non-negative float number")
+        return value
 
 
 backend = Backend()

--- a/renormalizer/mps/matrix.py
+++ b/renormalizer/mps/matrix.py
@@ -90,25 +90,29 @@ class Matrix:
     def l_combine(self):
         return self.reshape(self.l_combine_shape)
 
-    def check_lortho(self, atol=None):
+    def check_lortho(self, rtol: float = None, atol: float = None):
         """
         check L-orthogonal
         """
         if atol is None:
             atol = backend.canonical_atol
+        if rtol is None:
+            rtol = backend.canonical_rtol
         tensm = asxp(self.array.reshape([np.prod(self.shape[:-1]), self.shape[-1]]))
         s = tensm.T.conj() @ tensm
-        return xp.allclose(s, xp.eye(s.shape[0]), atol=atol)
+        return xp.allclose(s, xp.eye(s.shape[0]), rtol=rtol, atol=atol)
 
-    def check_rortho(self, atol=None):
+    def check_rortho(self, rtol: float = None, atol: float = None):
         """
         check R-orthogonal
         """
         if atol is None:
             atol = backend.canonical_atol
+        if rtol is None:
+            rtol = backend.canonical_rtol
         tensm = asxp(self.array.reshape([self.shape[0], np.prod(self.shape[1:])]))
         s = tensm @ tensm.T.conj()
-        return xp.allclose(s, xp.eye(s.shape[0]), atol=atol)
+        return xp.allclose(s, xp.eye(s.shape[0]), rtol=rtol, atol=atol)
 
     def to_complex(self):
         # `xp.array` always creates new array, so to_complex means copy, which is

--- a/renormalizer/mps/tests/test_backend.py
+++ b/renormalizer/mps/tests/test_backend.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# Author: Yu Xiong <y-xiong22@mails.tsinghua.edu.cn>
+
+import pytest
+
+from renormalizer.mps import backend
+
+
+def set_tolerance(tolerance_type, value):
+    setattr(backend, tolerance_type, value)
+
+
+def get_tolerance(tolerance_type):
+    return getattr(backend, tolerance_type)
+
+
+@pytest.mark.parametrize(
+    "tolerance_type, value",
+    [
+        ("canonical_atol", 1e-5),       # normal
+        ("canonical_atol", -1e-7),      # ValueError
+        ("canonical_atol", "invalid"),  # ValueError
+        ("canonical_rtol", 1e-4),       # normal
+        ("canonical_rtol", -1e-6),      # ValueError
+        ("canonical_rtol", "invalid"),  # ValueError
+    ],
+)
+def test_tolerances(tolerance_type, value):
+    if isinstance(value, (int, float)) and value >= 0:
+        set_tolerance(tolerance_type, value)
+        assert get_tolerance(tolerance_type) == value
+    else:
+        with pytest.raises(ValueError):
+            set_tolerance(tolerance_type, value)


### PR DESCRIPTION
In commit 254b981, `atol` for numpy backend was wrongly set to `1e-5` in `mps/backend.py`, instead of the original value `1e-8`. Meanwhile, in this version only `atol` was set up.

https://github.com/shuaigroup/Renormalizer/blob/254b9819d0e9124736d9c1681de0ec7bc60792bb/renormalizer/mps/backend.py#L136-L140

As for `numpy`, the basic logic for considering two numbers `a` and `b` close in is:
```python
abs(a - b) <= max(rtol * max(abs(a), abs(b)), atol)
```
The existence of `rtol` allows for the comparison of large numbers, e.g., 10001 and 10000, which may emerge in imaginary time-evolution. Therefore, I propose adding back the rtol parameter.

-----

This commit does the following things:

- Correct the values of `mps.backend.canonical_rtol` and `mps.backend.canonical_atol` 
- Add a setter for the above properties
- Use the tols as default parameter values in `mps.matrix.check_lortho`, `mps.mp.check_left_canonical`, `mps.mp.ensure_left_canonical` and their right counterparts

I am not sure whether `rtol` set to 1e-2 is appropriate for 32-bits. Discussions are welcome for any issue concerned : )