### PR TITLE
Add DMRG pyscf solver interface

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,8 +41,12 @@ jobs:
               pip install pytest-xdist pytest-cov
               export RENO_NUM_THREADS=1
               pytest -n 4 --durations=0 --cov=renormalizer renormalizer
-              pip install primme==3.2.*
+      - run:
+          name: Run optional tests
+          command: |
+              pip install primme==3.2.* pyscf==2.4.0
               pytest --durations=0 renormalizer/mps/tests/test_gs.py::test_multistate --cov=renormalizer --cov-append
+              pytest --durations=0 renormalizer/mps/tests/test_gs.py::test_pyscf_solver --cov=renormalizer --cov-append
       - run:
           name: Run examples
           command: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,16 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --no-cache-dir -r requirements.txt
-      - name: test scripts
+      - name: run tests
         run: |
           pip install pytest-xdist pytest-cov
           export RENO_NUM_THREADS=1
           pytest -n 4 --durations=0 --cov=renormalizer renormalizer
-          pip install primme==3.2.*
+      - name: run optional tests
+        run: |
+          pip install primme==3.2.* pyscf==2.4.0
           pytest --durations=0 renormalizer/mps/tests/test_gs.py::test_multistate --cov=renormalizer --cov-append
+          pytest --durations=0 renormalizer/mps/tests/test_gs.py::test_pyscf_solver --cov=renormalizer --cov-append
       - name: run examples
         run: |
             cd example; bash run.sh

--- a/renormalizer/__init__.py
+++ b/renormalizer/__init__.py
@@ -38,5 +38,5 @@ del os, log_level, init_log
 from renormalizer.model import Model, HolsteinModel, SpinBosonModel, TI1DModel, Op, OpSum
 from renormalizer.model.basis import BasisSHO, BasisHopsBoson, BasisSineDVR, BasisMultiElectron, \
     BasisMultiElectronVac, BasisSimpleElectron, BasisHalfSpin, BasisDummy
-from renormalizer.mps import Mpo, Mps, optimize_mps
+from renormalizer.mps import Mpo, Mps, optimize_mps, DmrgFCISolver
 from renormalizer.utils import Quantity

--- a/renormalizer/mps/__init__.py
+++ b/renormalizer/mps/__init__.py
@@ -3,5 +3,5 @@ from renormalizer.mps.mpo import Mpo, StackedMpo
 from renormalizer.mps.mps import Mps, BraKetPair
 from renormalizer.mps.mpdm import MpDm
 from renormalizer.mps.thermalprop import ThermalProp, load_thermal_state
-from renormalizer.mps.gs import optimize_mps
+from renormalizer.mps.gs import optimize_mps, DmrgFCISolver
 from renormalizer.mps.tda import TDA

--- a/renormalizer/mps/gs.py
+++ b/renormalizer/mps/gs.py
@@ -584,6 +584,7 @@ class DmrgFCISolver:
         self.mps: Mps = None
         self.nsorb: int = None
         self.bond_dimension: int = 32
+        self.procedure = None
         self.rdm1_mpos = []
         self.rdm2_mpos = []
 
@@ -611,7 +612,10 @@ class DmrgFCISolver:
         M = self.bond_dimension
         mps = Mps.random(model, nelec, M, percent=1.0)
 
-        mps.optimize_config.procedure = [[M, 0.4], [M, 0.2], [M, 0.1], [M, 0], [M, 0], [M, 0], [M, 0]]
+        if self.procedure is None:
+            mps.optimize_config.procedure = [[M, 0.4], [M, 0.2], [M, 0.1], [M, 0], [M, 0], [M, 0], [M, 0]]
+        else:
+            mps.optimize_config.procedure = self.procedure
         mps.optimize_config.method = "2site"
         energies, mps = optimize_mps(mps.copy(), mpo)
         gs_e = min(energies) + ecore

--- a/renormalizer/mps/mps.py
+++ b/renormalizer/mps/mps.py
@@ -1599,6 +1599,9 @@ class Mps(MatrixProduct):
         r"""Calculate the reduced density matrix of electronic DoF
         
         :math:`\rho_{ij} = \langle \Psi | a_i^\dagger a_j | \Psi \rangle`
+
+        .. note::
+            This function is designed for single-electron system. Fermionic commutation relation is not considered.
         
         """
         


### PR DESCRIPTION
Allow renormalizer to interface with PySCF as a FCI solver. Ab initio calculation with renormalizer can now be performed using a few lines of code by PySCF.